### PR TITLE
Test namespacing

### DIFF
--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -5,11 +5,9 @@
  * @package WP101
  */
 
-namespace WP101\Admin;
+namespace WP101\Tests;
 
-use WP101\Admin;
-use WP101\API;
-use WP101\TestCase;
+use WP101\Admin as Admin;
 
 /**
  * Tests for the plugin settings UI, defined in includes/settings.php.
@@ -28,7 +26,7 @@ class AdminTest extends TestCase {
 		$this->assertFalse( wp_style_is( 'wp101', 'registered' ) );
 		$this->assertFalse( wp_script_is( 'wp101', 'registered' ) );
 
-		enqueue_scripts( 'some-hook' );
+		Admin\enqueue_scripts( 'some-hook' );
 
 		$this->assertTrue(
 			wp_style_is( 'wp101', 'registered' ),
@@ -41,7 +39,7 @@ class AdminTest extends TestCase {
 	}
 
 	public function test_enqueue_scripts_only_enqueues_on_wp101_pages() {
-		enqueue_scripts( 'some-hook' );
+		Admin\enqueue_scripts( 'some-hook' );
 
 		$this->assertFalse(
 			wp_style_is( 'wp101', 'enqueued' ),
@@ -52,7 +50,7 @@ class AdminTest extends TestCase {
 			'WP101 scripts should only be enqueued on WP101 pages.'
 		);
 
-		enqueue_scripts( 'toplevel_page_wp101' );
+		Admin\enqueue_scripts( 'toplevel_page_wp101' );
 
 		$this->assertTrue(
 			wp_style_is( 'wp101', 'enqueued' ),

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -5,13 +5,12 @@
  * @package WP101
  */
 
-namespace WP101;
+namespace WP101\Tests;
 
 use ReflectionProperty;
 use WP_Error;
-use WP101_Plugin;
 use WP101\API;
-use WP101\TestCase;
+use WP101_Plugin;
 
 /**
  * Tests for the core plugin functionality, contained in includes/class-api.php.

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -5,10 +5,9 @@
  * @package WP101
  */
 
-namespace WP101\Core;
+namespace WP101\Tests;
 
 use WP101_Plugin;
-use WP101\TestCase;
 
 /**
  * Tests for the core plugin functionality, contained in includes/core.php.

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -5,10 +5,9 @@
  * @package WP101
  */
 
-namespace WP101;
+namespace WP101\Tests;
 
-use WP101\Admin;
-use WP101\TestCase;
+use WP101\Admin as Admin;
 
 /**
  * Tests for the plugin template tags, contained in includes/template-tags.php.

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -5,9 +5,9 @@
  * @package WP101
  */
 
-namespace WP101\TemplateTags;
+namespace WP101\Tests;
 
-use WP101\TestCase;
+use WP101\TemplateTags as TemplateTags;
 
 /**
  * Tests for the plugin template tags, contained in includes/template-tags.php.
@@ -17,10 +17,10 @@ class TemplateTagsTest extends TestCase {
 	public function test_get_api_key() {
 		$key = $this->set_api_key();
 
-		$this->assertEquals( $key, get_api_key() );
+		$this->assertEquals( $key, TemplateTags\get_api_key() );
 	}
 
 	public function test_get_api_key_can_return_empty_string() {
-		$this->assertEmpty( get_api_key() );
+		$this->assertEmpty( TemplateTags\get_api_key() );
 	}
 }

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -5,9 +5,7 @@
  * @package WP101
  */
 
-namespace WP101\Settings;
-
-use WP101\TestCase;
+namespace WP101\Tests;
 
 /**
  * Tests for the plugin's uninstallation procedure, defined in uninstall.php.

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -5,7 +5,7 @@
  * @package WP101
  */
 
-namespace WP101;
+namespace WP101\Tests;
 
 use Mockery;
 use ReflectionMethod;


### PR DESCRIPTION
This PR moves all of the tests into the `WP101\Tests` namespace — no code is changed within the actual plugin functionality.

Blocked by #4.