### PR TITLE
WP101 5.x migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ matrix:
       env: WP_VERSION=latest
 
 install:
-  - composer install --prefer-source --no-scripts
+  - |
+    wget https://github.com/runkit7/runkit7/releases/download/1.0.5b1/runkit-1.0.5b1.tgz &&
+    pecl install runkit-1.0.5b1.tgz
+  - composer install --prefer-dist --no-scripts
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,8 @@ matrix:
       env: WP_VERSION=latest
 
 install:
-  - |
-    wget https://github.com/runkit7/runkit7/releases/download/1.0.5b1/runkit-1.0.5b1.tgz &&
-    pecl install runkit-1.0.5b1.tgz
   - composer install --prefer-dist --no-scripts
+  - sudo ./vendor/bin/install-runkit.sh
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ matrix:
       env: WP_VERSION=latest
 
 install:
+  - |
+    wget https://github.com/runkit7/runkit7/releases/download/1.0.5b1/runkit-1.0.5b1.tgz &&
+    pecl install runkit-1.0.5b1.tgz
   - composer install --prefer-dist --no-scripts
-  - sudo ./vendor/bin/install-runkit.sh
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -41,11 +41,12 @@
   },
   "require": {},
   "require-dev": {
-    "mockery/mockery": "^1.0",
     "php": "^7.0",
+    "mockery/mockery": "^1.0",
     "phpunit/phpunit": "^6.5",
-    "stevegrunwell/wp-enforcer": "^0.5.0",
-    "stevegrunwell/phpunit-markup-assertions": "^1.0"
+    "stevegrunwell/phpunit-markup-assertions": "^1.0",
+    "stevegrunwell/runkit7-installer": "^1.0",
+    "stevegrunwell/wp-enforcer": "^0.5.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d879852102befdc701b480d2f03264b",
+    "content-hash": "39fd099b3b60fb466dab180b70f45725",
     "packages": [],
     "packages-dev": [
         {
@@ -1582,6 +1582,46 @@
                 "testing"
             ],
             "time": "2018-01-14T22:00:53+00:00"
+        },
+        {
+            "name": "stevegrunwell/runkit7-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stevegrunwell/runkit7-installer.git",
+                "reference": "ee618b7877fb1d6cb5930f48c9b845044c4c684c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stevegrunwell/runkit7-installer/zipball/ee618b7877fb1d6cb5930f48c9b845044c4c684c",
+                "reference": "ee618b7877fb1d6cb5930f48c9b845044c4c684c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php": "^7.0",
+                "phpunit/phpunit": ">=6.0"
+            },
+            "bin": [
+                "bin/install-runkit.sh"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Steve Grunwell",
+                    "email": "steve@stevegrunwell.com",
+                    "homepage": "https://stevegrunwell.com"
+                }
+            ],
+            "description": "Installer for PHP Runkit7",
+            "keywords": [
+                "runkit",
+                "testing"
+            ],
+            "time": "2018-03-30T03:00:06+00:00"
         },
         {
             "name": "stevegrunwell/wp-enforcer",

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -121,7 +121,7 @@ function render_addons_page() {
 	$addons    = $api->get_addons();
 	$purchased = wp_list_pluck( $api->get_playlist()['series'], 'slug' );
 
-	require_once WP101_VIEWS . '/add-ons.php';
+	include WP101_VIEWS . '/add-ons.php';
 }
 
 /**
@@ -132,14 +132,14 @@ function render_listings_page() {
 	$playlist   = $api->get_playlist();
 	$public_key = $api->get_public_api_key();
 
-	require_once WP101_VIEWS . '/listings.php';
+	include WP101_VIEWS . '/listings.php';
 }
 
 /**
  * Render the WP101 settings page.
  */
 function render_settings_page() {
-	require_once WP101_VIEWS . '/settings.php';
+	include WP101_VIEWS . '/settings.php';
 }
 
 /**

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -8,6 +8,7 @@
 namespace WP101\Admin;
 
 use WP101\API;
+use WP101\Migrate as Migrate;
 use WP101\TemplateTags as TemplateTags;
 
 /**
@@ -117,6 +118,8 @@ add_action( 'admin_init', __NAMESPACE__ . '\register_settings' );
  * Render the WP101 add-ons page.
  */
 function render_addons_page() {
+	Migrate\maybe_migrate();
+
 	$api       = TemplateTags\api();
 	$addons    = $api->get_addons();
 	$purchased = wp_list_pluck( $api->get_playlist()['series'], 'slug' );
@@ -128,6 +131,8 @@ function render_addons_page() {
  * Render the WP101 listings page.
  */
 function render_listings_page() {
+	Migrate\maybe_migrate();
+
 	$api        = TemplateTags\api();
 	$playlist   = $api->get_playlist();
 	$public_key = $api->get_public_api_key();
@@ -139,6 +144,11 @@ function render_listings_page() {
  * Render the WP101 settings page.
  */
 function render_settings_page() {
+	Migrate\maybe_migrate();
+
+	/** This action is documented in wp-admin/admin-header.php. */
+	do_action( 'admin_notices' );
+
 	include WP101_VIEWS . '/settings.php';
 }
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -96,6 +96,15 @@ class API {
 	}
 
 	/**
+	 * Explicitly set the API key.
+	 *
+	 * @param string $key The API key to use.
+	 */
+	public function set_api_key( $key ) {
+		$this->api_key = $key;
+	}
+
+	/**
 	 * Retrieve the public API key from WP101.
 	 *
 	 * Public API keys are generated on a per-domain basis by the WP101 API, and thus are safe for

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -86,7 +86,7 @@ class API {
 			return $this->api_key;
 		}
 
-		if ( defined( 'WP101_API_KEY' ) ) {
+		if ( defined( 'WP101_API_KEY' ) && ! Migrate\wp_config_requires_updating( WP101_API_KEY ) ) {
 			$this->api_key = WP101_API_KEY;
 		} else {
 			$this->api_key = get_option( 'wp101_api_key', '' );

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -250,7 +250,7 @@ class API {
 	 */
 	public function exchange_api_key() {
 		$response = wp_remote_post( $this->build_uri( '/key-exchange' ), [
-			'timeout'    => 10,
+			'timeout'    => 30,
 			'user-agent' => self::USER_AGENT,
 			'body'       => [
 				'apiKey' => $this->get_api_key(),

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -246,6 +246,36 @@ class API {
 	}
 
 	/**
+	 * Exchange a legacy API key for a 5.x API key.
+	 */
+	public function exchange_api_key() {
+		$response = wp_remote_post( $this->build_uri( '/key-exchange' ), [
+			'timeout'    => 10,
+			'user-agent' => self::USER_AGENT,
+			'body'       => [
+				'apiKey' => $this->get_api_key(),
+				'domain' => site_url(),
+			],
+		] );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 'fail' === $body['status'] ) {
+			return new WP_Error(
+				'wp101-api',
+				__( 'The WP101 API request failed.', 'wp101' ),
+				$body['data']
+			);
+		}
+
+		return $body['data'];
+	}
+
+	/**
 	 * Build an API request URI.
 	 *
 	 * @param string $path Optional. The API endpoint. Default is '/'.

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Migrations for previous versions of WP101.
+ *
+ * @package WP101
+ */
+
+namespace WP101\Migrate;
+
+use WP101\TemplateTags as TemplateTags;
+
+/**
+ * Determine whether the API key option requires migration.
+ *
+ * @param string $api_key Optional. The current API key to evaluate. Default is null.
+ *
+ * @return bool Whether or not the API key needs exchanged.
+ */
+function api_key_needs_migration( $api_key = null ) {
+	if ( ! $api_key ) {
+		$api_key = TemplateTags\api()->get_api_key();
+	}
+
+	return 32 !== strlen( $api_key );
+}
+
+/**
+ * Notify the user if the WP101_API_KEY constant in wp-config.php requires updating.
+ *
+ * If the constant is undefined, this will always return false.
+ *
+ * @return bool Whether or not the WP101_API_KEY constant requires updating.
+ */
+function wp_config_requires_updating() {
+	if ( ! defined( 'WP101_API_KEY' ) ) {
+		return false;
+	}
+
+	return api_key_needs_migration( WP101_API_KEY );
+}

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -10,6 +10,33 @@ namespace WP101\Migrate;
 use WP101\TemplateTags as TemplateTags;
 
 /**
+ * Apply any necessary migrations.
+ */
+function maybe_migrate() {
+	if ( ! api_key_needs_migration() ) {
+		return;
+	}
+
+	$api = TemplateTags\api();
+	$key = $api->exchange_api_key();
+
+	if ( is_wp_error( $key ) ) {
+		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		trigger_error( esc_html( $key->get_error_message() ), E_USER_WARNING );
+		// phpcs:enable
+
+		add_action( 'admin_notices', __NAMESPACE__ . '\render_migration_failure_notice' );
+
+		return;
+	}
+
+	update_option( 'wp101_api_key', $key['apiKey'], false );
+	$api->set_api_key( $key['apiKey'] );
+
+	add_action( 'admin_notices', __NAMESPACE__ . '\render_migration_success_notice' );
+}
+
+/**
  * Determine whether the API key option requires migration.
  *
  * @param string $api_key Optional. The current API key to evaluate. Default is null.
@@ -37,4 +64,30 @@ function wp_config_requires_updating() {
 	}
 
 	return api_key_needs_migration( WP101_API_KEY );
+}
+
+/**
+ * Display a notification when an automatic migration has succeeded.
+ */
+function render_migration_success_notice() {
+?>
+
+	<div class="notice notice-success">
+		<p><?php esc_html_e( 'WP101 has automatically upgraded your API key to work with the latest version!', 'wp101' ); ?></p>
+	</div>
+
+<?php
+}
+
+/**
+ * Display a notification when an automatic migration has failed.
+ */
+function render_migration_failure_notice() {
+?>
+
+	<div class="notice notice-error">
+		<p><?php esc_html_e( 'WP101 was unable to automatically migrate your API key for the latest version.', 'wp101' ); ?></p>
+	</div>
+
+<?php
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,6 +12,12 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+if ( ! function_exists( 'runkit_constant_remove' ) ) {
+	echo "\033[0;33mWARNING: Runkit is not active in the current environment, so not all tests can be run.\033[0;0m" . PHP_EOL;
+	echo 'You may install Runkit easily by running:' . PHP_EOL;
+	echo "  ./vendor/bin/install-runkit.sh" . PHP_EOL . PHP_EOL;
+}
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -143,7 +143,7 @@ class AdminTest extends TestCase {
 
 		return [
 			'parent'   => $menu[0],
-			'children' => $submenu['wp101'],
+			'children' => isset( $submenu['wp101'] ) ? $submenu['wp101'] : [],
 		];
 	}
 }

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -27,20 +27,11 @@ class ApiTest extends TestCase {
 
 	public function test_get_api_key_returns_from_cache() {
 		$api = API::get_instance();
-		$key = uniqid();
+		$key = md5( uniqid() );
 
 		$prop = new ReflectionProperty( $api, 'api_key' );
 		$prop->setAccessible( true );
 		$prop->setValue( $api, $key );
-
-		$this->assertEquals( $key, $api->get_api_key() );
-	}
-
-	public function test_set_api_key() {
-		$api = API::get_instance();
-		$key = uniqid();
-
-		$api->set_api_key( $key );
 
 		$this->assertEquals( $key, $api->get_api_key() );
 	}
@@ -52,7 +43,7 @@ class ApiTest extends TestCase {
 	}
 
 	public function test_get_api_key_reads_from_options() {
-		$key = uniqid();
+		$key = md5( uniqid() );
 		$this->set_api_key( $key );
 
 		$this->assertFalse(
@@ -61,6 +52,15 @@ class ApiTest extends TestCase {
 		);
 
 		$this->assertEquals( $key, API::get_instance()->get_api_key() );
+	}
+
+	public function test_set_api_key() {
+		$api = API::get_instance();
+		$key = md5( uniqid() );
+
+		$api->set_api_key( $key );
+
+		$this->assertEquals( $key, $api->get_api_key() );
 	}
 
 	public function test_has_api_key() {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -325,6 +325,44 @@ class ApiTest extends TestCase {
 		$this->assertFalse( API::get_instance()->account_can( 'some-capability' ) );
 	}
 
+	public function test_exchange_api_key() {
+		$api = API::get_instance();
+		$api->set_api_key( uniqid() );
+		$new = md5( uniqid() ); // Easy way to get a random, 32 character string.
+
+		$this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => [
+					'apiKey' => $new,
+				],
+			] ),
+		] );
+
+		$this->assertEquals( $new, $api->exchange_api_key()['apiKey'] );
+	}
+
+	public function test_exchange_api_key_surfaces_wp_errors() {
+		$error = new WP_Error( 'msg' );
+
+		$this->set_expected_response( function () use ( $error ) {
+			return $error;
+		} );
+
+		$this->assertSame( $error, API::get_instance()->exchange_api_key() );
+	}
+
+	public function test_exchange_api_key_returns_wp_error_on_api_error() {
+		$this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status' => 'fail',
+				'data' => 'some message',
+			] ),
+		] );
+
+		$this->assertTrue( is_wp_error( API::get_instance()->exchange_api_key() ) );
+	}
+
 	/**
 	 * @dataProvider build_uri_provider()
 	 */

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -37,9 +37,15 @@ class ApiTest extends TestCase {
 	}
 
 	public function test_get_api_key_reads_constant() {
-		define( 'WP101_API_KEY', uniqid() );
+		define( 'WP101_API_KEY', md5( uniqid() ) );
 
 		$this->assertEquals( WP101_API_KEY, API::get_instance()->get_api_key() );
+	}
+
+	public function test_get_api_key_only_considers_valid_constants() {
+		define( 'WP101_API_KEY', uniqid() );
+
+		$this->assertEmpty( API::get_instance()->get_api_key() );
 	}
 
 	public function test_get_api_key_reads_from_options() {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -36,6 +36,15 @@ class ApiTest extends TestCase {
 		$this->assertEquals( $key, $api->get_api_key() );
 	}
 
+	public function test_set_api_key() {
+		$api = API::get_instance();
+		$key = uniqid();
+
+		$api->set_api_key( $key );
+
+		$this->assertEquals( $key, $api->get_api_key() );
+	}
+
 	public function test_get_api_key_reads_constant() {
 		define( 'WP101_API_KEY', uniqid() );
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -37,8 +37,6 @@ class ApiTest extends TestCase {
 	}
 
 	public function test_get_api_key_reads_constant() {
-		$this->markTestSkipped( 'Defining the constant in a test will break other tests.' );
-
 		define( 'WP101_API_KEY', uniqid() );
 
 		$this->assertEquals( WP101_API_KEY, API::get_instance()->get_api_key() );

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -36,12 +36,18 @@ class ApiTest extends TestCase {
 		$this->assertEquals( $key, $api->get_api_key() );
 	}
 
+	/**
+	 * @requires extension runkit
+	 */
 	public function test_get_api_key_reads_constant() {
 		define( 'WP101_API_KEY', md5( uniqid() ) );
 
 		$this->assertEquals( WP101_API_KEY, API::get_instance()->get_api_key() );
 	}
 
+	/**
+	 * @requires extension runkit
+	 */
 	public function test_get_api_key_only_considers_valid_constants() {
 		define( 'WP101_API_KEY', uniqid() );
 

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for WP101 migrations.
+ *
+ * @package WP101
+ */
+
+namespace WP101\Tests;
+
+use WP101\Migrate as Migrate;
+
+/**
+ * Tests for migrating from older versions of the WP101 plugin.
+ */
+class MigrateTest extends TestCase {
+
+	/**
+	 * @dataProvider api_key_provider()
+	 */
+	public function test_api_key_needs_migration( $key, $expected ) {
+		update_option( 'wp101_api_key', $key, false );
+
+		$this->assertEquals( $expected, Migrate\api_key_needs_migration() );
+	}
+
+	/**
+	 * @dataProvider api_key_provider()
+	 */
+	public function test_api_key_needs_migration_with_passed_value( $key, $expected ) {
+		$this->assertEquals( $expected, Migrate\api_key_needs_migration( $key ) );
+	}
+
+	public function api_key_provider() {
+		return [
+			'Legacy API key'  => [ 'abcdefghijkl', true ],
+			'Current API key' => [ 'abcdefghijklmnopqrstuvwxyz123456', false ],
+		];
+	}
+
+	public function test_wp_config_requires_updating_without_constant() {
+		$this->assertFalse( defined( 'WP101_API_KEY' ) );
+		$this->assertFalse( Migrate\wp_config_requires_updating() );
+	}
+
+	/**
+	 * @requires extension runkit
+	 */
+	public function test_wp_config_requires_updating_with_old_constant() {
+		define( 'WP101_API_KEY', 'abcdefghijkl' );
+
+		$this->assertTrue( Migrate\wp_config_requires_updating() );
+	}
+
+	/**
+	 * @requires extension runkit
+	 */
+	public function test_wp_config_requires_updating_with_new_constant() {
+		define( 'WP101_API_KEY', 'abcdefghijklmnopqrstuvwxyz123456' );
+
+		$this->assertFalse( Migrate\wp_config_requires_updating() );
+	}
+}

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -7,12 +7,65 @@
 
 namespace WP101\Tests;
 
+use PHPUnit\Framework\Error\Warning;
+use WP_Error;
 use WP101\Migrate as Migrate;
 
 /**
  * Tests for migrating from older versions of the WP101 plugin.
  */
 class MigrateTest extends TestCase {
+
+	const LEGACY_API_KEY = 'abcdefghijkl';
+
+	const CURRENT_API_KEY = 'abcdefghijklmnopqrstuvwxyz123456';
+
+	/**
+	 * @after
+	 */
+	public function remove_actions() {
+		remove_all_actions( 'admin_notices' );
+	}
+
+	public function test_maybe_migrate() {
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )
+			->once()
+			->andReturn( [
+				'apiKey' => self::CURRENT_API_KEY,
+			] );
+		$this->set_api_key( self::LEGACY_API_KEY );
+
+		Migrate\maybe_migrate();
+
+		$this->assertEquals( self::CURRENT_API_KEY, get_option( 'wp101_api_key' ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', 'WP101\Migrate\render_migration_success_notice' ) );
+	}
+
+	public function test_maybe_migrate_returns_early_if_keys_do_not_require_migration() {
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )->never();
+		$this->set_api_key( self::CURRENT_API_KEY );
+
+		Migrate\maybe_migrate();
+
+		$this->assertFalse( has_action( 'admin_notices' ) );
+	}
+
+	public function test_maybe_migrate_handles_wp_errors() {
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )
+			->once()
+			->andReturn( new WP_Error( 'some error' ) );
+		$this->set_api_key( self::LEGACY_API_KEY );
+
+		$this->expectException( Warning::class );
+
+		Migrate\maybe_migrate();
+
+		$this->assertEquals( self::LEGACY_API_KEY, get_option( 'wp101_api_key' ) );
+		$this->assertTrue( has_action( 'admin_notices', 'WP101\Migrate\render_migration_failure_notice' ) );
+	}
 
 	/**
 	 * @dataProvider api_key_provider()
@@ -32,8 +85,8 @@ class MigrateTest extends TestCase {
 
 	public function api_key_provider() {
 		return [
-			'Legacy API key'  => [ 'abcdefghijkl', true ],
-			'Current API key' => [ 'abcdefghijklmnopqrstuvwxyz123456', false ],
+			'Legacy API key'  => [ self::LEGACY_API_KEY, true ],
+			'Current API key' => [ self::CURRENT_API_KEY, false ],
 		];
 	}
 
@@ -46,7 +99,7 @@ class MigrateTest extends TestCase {
 	 * @requires extension runkit
 	 */
 	public function test_wp_config_requires_updating_with_old_constant() {
-		define( 'WP101_API_KEY', 'abcdefghijkl' );
+		define( 'WP101_API_KEY', self::LEGACY_API_KEY );
 
 		$this->assertTrue( Migrate\wp_config_requires_updating() );
 	}
@@ -55,8 +108,24 @@ class MigrateTest extends TestCase {
 	 * @requires extension runkit
 	 */
 	public function test_wp_config_requires_updating_with_new_constant() {
-		define( 'WP101_API_KEY', 'abcdefghijklmnopqrstuvwxyz123456' );
+		define( 'WP101_API_KEY', self::CURRENT_API_KEY );
 
 		$this->assertFalse( Migrate\wp_config_requires_updating() );
+	}
+
+	public function test_render_migration_success_notice() {
+		ob_start();
+		Migrate\render_migration_success_notice();
+		$output = ob_get_clean();
+
+		$this->assertContainsSelector( 'div.notice.notice-success', $output );
+	}
+
+	public function test_render_migration_failure_notice() {
+		ob_start();
+		Migrate\render_migration_failure_notice();
+		$output = ob_get_clean();
+
+		$this->assertContainsSelector( 'div.notice.notice-error', $output );
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -29,6 +29,8 @@ class SettingsTest extends TestCase {
 			],
 			$output
 		);
+
+		$this->assertEquals( 1, did_action( 'admin_notices' ) );
 	}
 
 	public function test_hides_api_key_form_if_set_via_constant() {

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -34,12 +34,23 @@ class SettingsTest extends TestCase {
 	}
 
 	public function test_hides_api_key_form_if_set_via_constant() {
-		define( 'WP101_API_KEY', uniqid() );
+		define( 'WP101_API_KEY', md5( uniqid() ) );
 
 		ob_start();
 		Admin\render_settings_page();
 		$output = ob_get_clean();
 
 		$this->assertNotContainsSelector( '#wp101-api-key', $output );
+	}
+
+	public function test_notifies_user_if_constant_needs_replaced() {
+		define( 'WP101_API_KEY', 'some-legacy-api-key' );
+
+		ob_start();
+		Admin\render_settings_page();
+		$output = ob_get_clean();
+
+		$this->assertContainsSelector( '#wp101-api-key', $output );
+		$this->assertContainsSelector( 'div.notice.notice-warning', $output );
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -32,14 +32,12 @@ class SettingsTest extends TestCase {
 	}
 
 	public function test_hides_api_key_form_if_set_via_constant() {
-		$this->markTestSkipped( 'Defining the constant in a test will break other tests.' );
-
 		define( 'WP101_API_KEY', uniqid() );
 
 		ob_start();
 		Admin\render_settings_page();
 		$output = ob_get_clean();
 
-		$this->assertNotContainsSelector('#wp101-api-key', $output);
+		$this->assertNotContainsSelector( '#wp101-api-key', $output );
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -33,6 +33,9 @@ class SettingsTest extends TestCase {
 		$this->assertEquals( 1, did_action( 'admin_notices' ) );
 	}
 
+	/**
+	 * @requires extension runkit
+	 */
 	public function test_hides_api_key_form_if_set_via_constant() {
 		define( 'WP101_API_KEY', md5( uniqid() ) );
 
@@ -43,6 +46,9 @@ class SettingsTest extends TestCase {
 		$this->assertNotContainsSelector( '#wp101-api-key', $output );
 	}
 
+	/**
+	 * @requires extension runkit
+	 */
 	public function test_notifies_user_if_constant_needs_replaced() {
 		define( 'WP101_API_KEY', 'some-legacy-api-key' );
 

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -59,10 +59,9 @@ class TestCase extends WP_UnitTestCase {
 	 * Clean up the WP101_API_KEY constant.
 	 *
 	 * @after
-	 * @requires extension runkit
 	 */
 	public function remove_constants() {
-		if ( defined( 'WP101_API_KEY' ) ) {
+		if ( function_exists( 'runkit_constant_remove' ) && defined( 'WP101_API_KEY' ) ) {
 			runkit_constant_remove( 'WP101_API_KEY' );
 		}
 	}

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -105,7 +105,7 @@ class TestCase extends WP_UnitTestCase {
 	 */
 	protected function set_api_key( $api_key = false ) {
 		if ( false === $api_key ) {
-			$api_key = uniqid();
+			$api_key = md5( uniqid() );
 		}
 
 		update_option( 'wp101_api_key', $api_key );

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -56,6 +56,18 @@ class TestCase extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Clean up the WP101_API_KEY constant.
+	 *
+	 * @after
+	 * @requires extension runkit
+	 */
+	public function remove_constants() {
+		if ( defined( 'WP101_API_KEY' ) ) {
+			runkit_constant_remove( 'WP101_API_KEY' );
+		}
+	}
+
+	/**
 	 * Return a ReflectionMethod with given protected/private $method accessible.
 	 *
 	 * @param  object|string $class  A class name or instance that contains the given method.

--- a/views/settings.php
+++ b/views/settings.php
@@ -5,6 +5,7 @@
  * @package WP101
  */
 
+use WP101\Migrate as Migrate;
 use WP101\TemplateTags as TemplateTags;
 
 ?>
@@ -18,12 +19,31 @@ use WP101\TemplateTags as TemplateTags;
 		<?php settings_fields( 'wp101' ); ?>
 
 		<section id="api-key">
-			<?php if ( defined( 'WP101_API_KEY' ) && WP101_API_KEY ) : ?>
+			<?php if ( defined( 'WP101_API_KEY' ) && ! Migrate\wp_config_requires_updating( WP101_API_KEY ) ) : ?>
 				<div class="notice notice-info">
 					<p><?php esc_html_e( 'Your API key has been set in your wp-config.php file.', 'wp101' ); ?></p>
 				</div>
 
 			<?php else : ?>
+				<?php if ( Migrate\wp_config_requires_updating() ) : ?>
+					<div class="notice notice-warning">
+						<p><?php esc_html_e( 'Your API key has been updated to work with the latest version of WP101, but your wp-config.php requires updating:', 'wp101' ); ?></p>
+						<ol>
+							<li><?php esc_html_e( 'Open your site\'s wp-config.php file in a text editor.', 'wp101' ); ?></li>
+							<li>
+								<?php
+									echo wp_kses_post( sprintf(
+										/* Translators: %1$s is a code snippet for "define( 'WP101_API_KEY', '...' );" in wp-config.php. */
+										__( 'Find the line that reads %1$s and either remove it completely or replace it with the following:', 'wp101' ),
+										sprintf( "<code>define( 'WP101_API_KEY', '%s' );</code>", WP101_API_KEY )
+									) );
+								?>
+								<pre><code>define( 'WP101_API_KEY', '<?php echo esc_html( TemplateTags\get_api_key() ); ?>' );</code></pre>
+							</li>
+							<li><?php esc_html_e( 'Save the wp-config.php file on your web server.', 'wp101' ); ?></li>
+					</div>
+				<?php endif; ?>
+
 				<h2><?php echo esc_html( _x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ) ); ?></h2>
 				<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
 				<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>

--- a/wp101.php
+++ b/wp101.php
@@ -15,6 +15,7 @@ define( 'WP101_VERSION', '5.0.0' );
 
 require_once WP101_INC . '/admin.php';
 require_once WP101_INC . '/class-api.php';
+require_once WP101_INC . '/migrate.php';
 require_once WP101_INC . '/shortcode.php';
 require_once WP101_INC . '/template-tags.php';
 require_once WP101_INC . '/uninstall.php';

--- a/wp101.php
+++ b/wp101.php
@@ -21,6 +21,11 @@ require_once WP101_INC . '/template-tags.php';
 require_once WP101_INC . '/uninstall.php';
 
 /**
+ * When the plugin is activated, check to see if it needs migrating from earlier versions.
+ */
+register_activation_hook( __FILE__, 'WP101\Migrate\maybe_migrate' );
+
+/**
  * Register the uninstall callback.
  */
 register_uninstall_hook( __FILE__, 'WP101\Uninstall\cleanup_plugin' );


### PR DESCRIPTION
This PR starts to define the migration path from earlier versions of the WP101 plugin to 5.x:

When the plugin is activated _or_ when the user visits a WP101 page (listings, settings, or add-ons), the API key will be checked against conventions for the Laravel SaaS (which uses 32-byte keys). If the key doesn't match, the plugin will attempt to exchange it via the `/api/key-exchange` SaaS API endpoint.

In the event that the `WP101_API_KEY` constant is set in `wp-config.php` and is using an older key, the new key will be saved to the options table and the `API` class will use that option instead of the deprecated key; instructions will be displayed at the top of the settings page showing users what constant needs changing in `wp-config.php` and the exact code to use.

Blocked by #8.