### PR TITLE
Migrate hidden topics

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -253,8 +253,20 @@ class API {
 			'timeout'    => 30,
 			'user-agent' => self::USER_AGENT,
 			'body'       => [
-				'apiKey' => $this->get_api_key(),
-				'domain' => site_url(),
+				'apiKey'       => $this->get_api_key(),
+				'domain'       => site_url(),
+
+				/**
+				 * Filter legacy WP101 topic IDs.
+				 *
+				 * This filter was available in WP101 4.x and below, and is only being applied so
+				 * that hidden topics are preserved during the API key exchange process.
+				 *
+				 * @deprecated 5.0.0
+				 *
+				 * @param array $topic_ids An array of WP101 topics that should be hidden.
+				 */
+				'hiddenTopics' => apply_filters( 'wp101_get_hidden_topics', get_option( 'wp101_hidden_topics' ) ),
 			],
 		] );
 

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -34,6 +34,9 @@ function maybe_migrate() {
 	$api->set_api_key( $key['apiKey'] );
 
 	add_action( 'admin_notices', __NAMESPACE__ . '\render_migration_success_notice' );
+
+	// Clean up old data.
+	delete_option( 'wp101_hidden_topics' );
 }
 
 /**

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -348,6 +348,51 @@ class ApiTest extends TestCase {
 		$this->assertEquals( $new, $api->exchange_api_key()['apiKey'] );
 	}
 
+	public function test_exchange_api_key_passes_hidden_topic_ids() {
+		$hidden = [ 4, 8, 15, 16, 23, 42 ];
+		update_option( 'wp101_hidden_topics', $hidden );
+
+		$api = API::get_instance();
+		$api->set_api_key( uniqid() );
+
+		$this->set_expected_response( function ( $preempt, $args ) use ( $hidden ) {
+			$this->assertEquals( $hidden, $args['body']['hiddenTopics'] );
+
+			return $this->mock_http_response( [
+				'body' => wp_json_encode( [
+					'status' => 'success',
+					'data'   => 'Hidden topics were passed!',
+				] ),
+			] );
+		} );
+
+		$this->assertEquals( 'Hidden topics were passed!', $api->exchange_api_key() );
+	}
+
+	public function test_exchange_api_key_respects_wp101_get_hidden_topics_filter() {
+		update_option( 'wp101_hidden_topics', [ 4, 8, 15, 16, 23, 42 ] );
+
+		add_filter( 'wp101_get_hidden_topics', function () {
+			return [ 4, 8, 15 ];
+		} );
+
+		$api = API::get_instance();
+		$api->set_api_key( uniqid() );
+
+		$this->set_expected_response( function ( $preempt, $args ) {
+			$this->assertEquals( [ 4, 8, 15 ], $args['body']['hiddenTopics'] );
+
+			return $this->mock_http_response( [
+				'body' => wp_json_encode( [
+					'status' => 'success',
+					'data'   => 'Hidden topics were passed!',
+				] ),
+			] );
+		} );
+
+		$this->assertEquals( 'Hidden topics were passed!', $api->exchange_api_key() );
+	}
+
 	public function test_exchange_api_key_surfaces_wp_errors() {
 		$error = new WP_Error( 'msg' );
 

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -36,10 +36,17 @@ class MigrateTest extends TestCase {
 			] );
 		$this->set_api_key( self::LEGACY_API_KEY );
 
+		// Populate some other legacy options.
+		update_option( 'wp101_hidden_topics', [ 1, 2, 3 ] );
+
 		Migrate\maybe_migrate();
 
 		$this->assertEquals( self::CURRENT_API_KEY, get_option( 'wp101_api_key' ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', 'WP101\Migrate\render_migration_success_notice' ) );
+		$this->assertFalse(
+			get_option( 'wp101_hidden_topics', false ),
+			'Expected the wp101_hidden_topics option to be deleted.'
+		);
 	}
 
 	public function test_maybe_migrate_returns_early_if_keys_do_not_require_migration() {


### PR DESCRIPTION
This PR passes hidden topic IDs to the WP101 SaaS API key exchange endpoint, ensuring that sites moving from 4.x to 5.x keep their hidden topics...well, hidden.

Blocked by #10, fixes #11.