### PR TITLE
Migrate custom topics

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -257,6 +257,16 @@ class API {
 				'domain'       => site_url(),
 
 				/**
+				 * Pass along custom topics to the key exchange, enabling these to be created
+				 * within WP101 automatically.
+				 *
+				 * @deprecated 5.0.0
+				 *
+				 * @param array $custom_topics An array of custom WP101 topics.
+				 */
+				'customTopics' => apply_filters( 'wp101_get_custom_help_topics', get_option( 'wp101_custom_topics' ) ),
+
+				/**
 				 * Filter legacy WP101 topic IDs.
 				 *
 				 * This filter was available in WP101 4.x and below, and is only being applied so

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -36,6 +36,7 @@ function maybe_migrate() {
 	add_action( 'admin_notices', __NAMESPACE__ . '\render_migration_success_notice' );
 
 	// Clean up old data.
+	delete_option( 'wp101_custom_topics' );
 	delete_option( 'wp101_hidden_topics' );
 }
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -393,6 +393,56 @@ class ApiTest extends TestCase {
 		$this->assertEquals( 'Hidden topics were passed!', $api->exchange_api_key() );
 	}
 
+	public function test_exchange_api_key_passes_custom_topics() {
+		$custom_topics = [
+			'custom-topic' => [
+				'title'   => 'This is a custom topic',
+				'content' => '<iframe src="//player.vimeo.com/video/123456789" width="1280" height="720" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
+			],
+		];
+		update_option( 'wp101_custom_topics', $custom_topics );
+
+		$api = API::get_instance();
+		$api->set_api_key( uniqid() );
+
+		$this->set_expected_response( function ( $preempt, $args ) use ( $custom_topics ) {
+			$this->assertEquals( $custom_topics, $args['body']['customTopics'] );
+
+			return $this->mock_http_response( [
+				'body' => wp_json_encode( [
+					'status' => 'success',
+					'data'   => 'Custom topics were passed!',
+				] ),
+			] );
+		} );
+
+		$this->assertEquals( 'Custom topics were passed!', $api->exchange_api_key() );
+	}
+
+	public function test_exchange_api_key_respects_wp101_get_custom_help_topics_filter() {
+		update_option( 'wp101_custom_topics', [ 'custom-topic' => [] ] );
+
+		add_filter( 'wp101_get_custom_help_topics', function () {
+			return [ 'different-topic' => [] ];
+		} );
+
+		$api = API::get_instance();
+		$api->set_api_key( uniqid() );
+
+		$this->set_expected_response( function ( $preempt, $args ) {
+			$this->assertEquals( [ 'different-topic'], array_keys( $args['body']['customTopics'] ) );
+
+			return $this->mock_http_response( [
+				'body' => wp_json_encode( [
+					'status' => 'success',
+					'data'   => 'Custom topics were passed!',
+				] ),
+			] );
+		} );
+
+		$this->assertEquals( 'Custom topics were passed!', $api->exchange_api_key() );
+	}
+
 	public function test_exchange_api_key_surfaces_wp_errors() {
 		$error = new WP_Error( 'msg' );
 

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -37,12 +37,22 @@ class MigrateTest extends TestCase {
 		$this->set_api_key( self::LEGACY_API_KEY );
 
 		// Populate some other legacy options.
+		update_option( 'wp101_custom_topics', [
+			'custom-topic' => [
+				'title'   => 'Custom Topic',
+				'content' => 'Some video embed',
+			],
+		] );
 		update_option( 'wp101_hidden_topics', [ 1, 2, 3 ] );
 
 		Migrate\maybe_migrate();
 
 		$this->assertEquals( self::CURRENT_API_KEY, get_option( 'wp101_api_key' ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', 'WP101\Migrate\render_migration_success_notice' ) );
+		$this->assertFalse(
+			get_option( 'wp101_custom_topics', false ),
+			'Expected the wp101_custom_topics option to be deleted.'
+		);
 		$this->assertFalse(
 			get_option( 'wp101_hidden_topics', false ),
 			'Expected the wp101_hidden_topics option to be deleted.'


### PR DESCRIPTION
Like #13, this PR enables content originally stored within the WordPress options table to the SaaS at the time of key migration.

Blocked by #13, fixes #12.