### PR TITLE
Append the public API key to add-on URLs

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -153,6 +153,20 @@ class API {
 			];
 		}
 
+		// Catch responses that don't contain an array of add-ons.
+		if ( ! isset( $response['addons'] ) ) {
+			return [
+				'addons' => [],
+			];
+		}
+
+		// Append the public API key to add-on URLs.
+		$api_key = $this->get_public_api_key();
+
+		array_walk( $response['addons'], function ( &$addon ) use ( $api_key ) {
+			$addon['url'] = add_query_arg( 'apiKey', $api_key, $addon['url'] );
+		} );
+
 		return $response;
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -144,7 +144,9 @@ class ApiTest extends TestCase {
 	public function test_get_addons() {
 		$json = [
 			'status' => 'success',
-			'data'   => [],
+			'data'   => [
+				'addons' => [],
+			],
 		];
 
 		$this->set_expected_response([
@@ -166,6 +168,47 @@ class ApiTest extends TestCase {
 				'addons' => [],
 			],
 			API::get_instance()->get_addons()
+		);
+	}
+
+	public function test_get_addons_handles_malformed_responses() {
+		$json = [
+			'status' => 'success',
+			'data'   => [
+				'some data that has nothing to do with add-ons.',
+			],
+		];
+
+		$this->set_expected_response([
+			'body' => wp_json_encode( $json ),
+		]);
+
+		$this->assertEquals( [
+			'addons' => [],
+		], API::get_instance()->get_addons() );
+	}
+
+	public function test_get_addons_updates_add_on_urls() {
+		$api_key = uniqid();
+
+		update_option( API::PUBLIC_API_KEY_OPTION, $api_key );
+		$this->set_expected_response([
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => [
+					'addons' => [
+						[
+							'url' => 'http://example.com',
+						],
+					],
+				],
+			] ),
+		]);
+
+		$this->assertEquals(
+			'http://example.com?apiKey=' . $api_key,
+			API::get_instance()->get_addons()['addons'][0]['url'],
+			'The public API key should be appended to all add-on URLs.'
 		);
 	}
 


### PR DESCRIPTION
This PR appends the site's public API key to the end of add-on URLs, allowing the SaaS to see a) what site referred the traffic and b) what relationships need to be maintained between parent and child accounts.