### PR TITLE
Include 'copy' in the Grunt build steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ assets/css/*.css
 assets/css/*.map
 assets/js/*.js
 assets/js/*.map
+dist
 node_modules
 tests/coverage
 vendor

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
 	});
 
 	grunt.loadNpmTasks( 'grunt-sass' );
-	grunt.loadNpmTasks('grunt-contrib-copy');
+	grunt.loadNpmTasks( 'grunt-contrib-copy' );
 	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
 	grunt.loadNpmTasks( 'grunt-eslint' );
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,25 @@ module.exports = function(grunt) {
 
 		pkg: grunt.file.readJSON('package.json'),
 
+		copy: {
+			main: {
+				src: [
+					'assets/**',
+					'!assets/*/scss/**',
+					'!assets/*/scss',
+					'!assets/*/src/**',
+					'!assets/*/src',
+					'includes/**',
+					'languages/**',
+					'views/**',
+					'composer.json',
+					'readme.txt',
+					'wp101.php'
+				],
+				dest: 'dist/'
+			},
+		},
+
 		cssmin: {
 			options: {
 				sourceMap: true
@@ -87,11 +106,12 @@ module.exports = function(grunt) {
 	});
 
 	grunt.loadNpmTasks( 'grunt-sass' );
+	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
 	grunt.loadNpmTasks( 'grunt-eslint' );
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 
-	grunt.registerTask( 'build', [ 'eslint', 'i18n', 'sass', 'uglify' ] );
+	grunt.registerTask( 'build', [ 'eslint', 'i18n', 'sass', 'uglify', 'copy' ] );
 	grunt.registerTask( 'i18n', [ 'makepot' ] );
 	grunt.registerTask( 'default', [ 'eslint', 'sass', 'uglify' ] );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -557,7 +557,7 @@
       "dependencies": {
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         }
@@ -817,6 +817,12 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-sync-cmp": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -1135,6 +1141,16 @@
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "file-sync-cmp": "^0.1.0"
       }
     },
     "grunt-contrib-uglify": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "private": true,
   "devDependencies": {
     "eslint-config-wordpress": "^2.0.0",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-uglify": "^3.3.0",
     "grunt-eslint": "^20.0.0",
     "grunt-sass": "^2.1.0",


### PR DESCRIPTION
This PR includes grunt-contrib-copy in the `grunt build`, creating a `dist/` directory (which is blocked from the repo), making it easier to make consistent builds for WordPress.org.

Fixes #24.