### PR TITLE
Better handling of API failures

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -298,6 +298,15 @@ class API {
 			return $response;
 		}
 
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( ! in_array( $response_code, [ 200, 201 ], true ) ) {
+			return new WP_Error(
+				'wp101-api',
+				__( 'The WP101 API request failed.', 'wp101' ),
+				$response
+			);
+		}
+
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		if ( 'fail' === $body['status'] ) {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -502,6 +502,17 @@ class ApiTest extends TestCase {
 		$this->assertSame( $error, API::get_instance()->exchange_api_key() );
 	}
 
+	public function test_exchange_api_key_returns_wp_error_on_api_connection_error() {
+		$this->set_expected_response( [
+			'response' => [
+				'code'    => 403,
+				'message' => 'Forbidden',
+			],
+		] );
+
+		$this->assertTrue( is_wp_error( API::get_instance()->exchange_api_key() ) );
+	}
+
 	public function test_exchange_api_key_returns_wp_error_on_api_error() {
 		$this->set_expected_response( [
 			'body' => wp_json_encode( [
@@ -645,8 +656,8 @@ class ApiTest extends TestCase {
 			'headers'  => [],
 			'body'     => '',
 			'response' => [
-				'code'    => false,
-				'message' => false,
+				'code'    => 200,
+				'message' => 'OK',
 			],
 			'cookies'  => [],
 			'filename' => '',

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -8,6 +8,7 @@
 namespace WP101\Tests;
 
 use WP101\Admin as Admin;
+use WP101\API;
 
 /**
  * Tests for the plugin template tags, contained in includes/template-tags.php.
@@ -58,5 +59,15 @@ class SettingsTest extends TestCase {
 
 		$this->assertContainsSelector( '#wp101-api-key', $output );
 		$this->assertContainsSelector( 'div.notice.notice-warning', $output );
+	}
+
+	public function test_public_key_is_cleared_when_private_key_changes() {
+		update_option( 'wp101_api_key', md5( uniqid() ) );
+		update_option( API::PUBLIC_API_KEY_OPTION, uniqid() );
+
+		// Change the private key.
+		update_option( 'wp101_api_key', md5( uniqid() ) );
+
+		$this->assertEmpty( get_option( API::PUBLIC_API_KEY_OPTION ) );
 	}
 }


### PR DESCRIPTION
This PR accomplishes two things:

1. If the `API::exchange_api_key()` method receives any response other than `200` or `201` from the SaaS API, return a `WP_Error` object. This will prevent affirmative messaging when the migration, in fact, failed (fixes #27).
2. Add an explicit test around the clearing of the `API::PUBLIC_API_KEY_OPTION` option when the private key changes.