### PR TITLE
PHP compatibility checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - |
     wget https://github.com/runkit7/runkit7/releases/download/1.0.5b1/runkit-1.0.5b1.tgz &&
     pecl install runkit-1.0.5b1.tgz
-  - composer install --prefer-dist --no-scripts
+  - composer install --prefer-dist
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ install:
   - composer install --prefer-dist --no-scripts
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
-before_script:
-  - ./vendor/bin/wp-enforcer
-
 script:
   - WP_MULTISITE=0 ./vendor/bin/phpunit
   - WP_MULTISITE=1 ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -47,13 +47,8 @@
     "phpunit/phpunit": "^6.5",
     "stevegrunwell/phpunit-markup-assertions": "^1.0",
     "stevegrunwell/runkit7-installer": "^1.0",
-    "stevegrunwell/wp-enforcer": "^0.5.0",
-    "wimg/php-compatibility": "^8.1"
-  },
-  "scripts": {
-    "post-install-cmd": [
-      "wp-enforcer"
-    ]
+    "wimg/php-compatibility": "^8.1",
+    "wp-coding-standards/wpcs": "^0.14.1"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.json
+++ b/composer.json
@@ -42,11 +42,13 @@
   "require": {},
   "require-dev": {
     "php": "^7.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "mockery/mockery": "^1.0",
     "phpunit/phpunit": "^6.5",
     "stevegrunwell/phpunit-markup-assertions": "^1.0",
     "stevegrunwell/runkit7-installer": "^1.0",
-    "stevegrunwell/wp-enforcer": "^0.5.0"
+    "stevegrunwell/wp-enforcer": "^0.5.0",
+    "wimg/php-compatibility": "^8.1"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -179,16 +179,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38"
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/1bac8c362b12f522fdd1f1fa3556284c91affa38",
-                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/99e29d3596b16dabe4982548527d5ddf90232e99",
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99",
                 "shasum": ""
             },
             "require": {
@@ -197,7 +197,8 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5.7|~6.1"
+                "phpdocumentor/phpdocumentor": "^2.9",
+                "phpunit/phpunit": "~5.7.10|~6.5"
             },
             "type": "library",
             "extra": {
@@ -226,8 +227,8 @@
                     "homepage": "http://davedevelopment.co.uk"
                 }
             ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-            "homepage": "http://github.com/mockery/mockery",
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
             "keywords": [
                 "BDD",
                 "TDD",
@@ -240,7 +241,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-10-06T16:20:43+00:00"
+            "time": "2018-05-08T08:54:48+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,77 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39fd099b3b60fb466dab180b70f45725",
+    "content-hash": "bb2c5f352625fe6de0568cd285c16a4a",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06T16:27:17+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -1753,6 +1821,58 @@
                 "validate"
             ],
             "time": "2018-01-29T19:49:41+00:00"
+        },
+        {
+            "name": "wimg/php-compatibility",
+            "version": "8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wimg/PHPCompatibility.git",
+                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-12-27T21:58:38+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb2c5f352625fe6de0568cd285c16a4a",
+    "content-hash": "6d98c8863415ec82e040faa7b0b5aa81",
     "packages": [],
     "packages-dev": [
         {
@@ -1691,47 +1691,6 @@
                 "testing"
             ],
             "time": "2018-03-30T03:00:06+00:00"
-        },
-        {
-            "name": "stevegrunwell/wp-enforcer",
-            "version": "v0.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/stevegrunwell/wp-enforcer.git",
-                "reference": "6d583588d06346982b5819066f14675ddc8004d7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/stevegrunwell/wp-enforcer/zipball/6d583588d06346982b5819066f14675ddc8004d7",
-                "reference": "6d583588d06346982b5819066f14675ddc8004d7",
-                "shasum": ""
-            },
-            "require": {
-                "wp-coding-standards/wpcs": "*"
-            },
-            "bin": [
-                "bin/wp-enforcer"
-            ],
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Steve Grunwell",
-                    "email": "steve@stevegrunwell.com",
-                    "homepage": "https://stevegrunwell.com"
-                }
-            ],
-            "description": "Git hooks to encourage well-written WordPress.",
-            "keywords": [
-                "PHP_CodeSniffer",
-                "coding standards",
-                "git hooks",
-                "wordpress"
-            ],
-            "time": "2017-05-28T18:44:13+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -45,7 +45,7 @@ function render_shortcode( $atts ) {
 	if ( ! $api->account_can( 'embed-on-front-end' ) ) {
 		return shortcode_debug( __( 'Your WP101 subscription does not permit embedding on the front-end of a site.', 'wp101' ) );
 
-	} elseif ( 'private' !== get_post_status() && empty( get_post()->post_password ) ) {
+	} elseif ( 'private' !== get_post_status() && ! get_post()->post_password ) {
 		return shortcode_debug( __( 'You may not use WP101 shortcodes on public pages.', 'wp101' ) );
 	}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,17 +6,25 @@
 <ruleset name="wp101">
 	<description>Coding standards for WP101.</description>
 
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
 	<!-- FILES -->
-	<exclude-pattern>phpcs.xml</exclude-pattern>
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>Gruntfile.js</exclude-pattern>
+	<exclude-pattern>assets/*</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
+	<exclude-pattern>tests/*</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
 
 	<!-- Temporary exclusion for legacy code. -->
-	<exclude-pattern>*/assets/*</exclude-pattern>
 	<exclude-pattern>integrations/*</exclude-pattern>
-	<exclude-pattern>wp101.php</exclude-pattern>
+
+	<!-- PHP Compatibility sniffs. -->
+	<rule ref="PHPCompatibility"/>
+	<config name="testVersion" value="5.4-" />
 
 	<!-- Long conditionals. -->
 	<rule ref="Squiz.Commenting.LongConditionClosingComment.Missing">

--- a/views/listings.php
+++ b/views/listings.php
@@ -40,7 +40,9 @@ $query_args = array(
 				 * does not meet (e.g. "don't show Jetpack videos on a site not running Jetpack.").
 				 */
 				if ( ! empty( $series['restrictions'] ) && ! empty( $series['restrictions']['plugins'] ) ) {
-					if ( empty( array_filter( $series['restrictions']['plugins'], 'is_plugin_active' ) ) ) {
+					$restrictions = array_filter( $series['restrictions']['plugins'], 'is_plugin_active' );
+
+					if ( empty( $restrictions ) ) {
 						continue;
 					}
 				} elseif ( empty( $series['topics'] ) ) {

--- a/wp101.php
+++ b/wp101.php
@@ -1,18 +1,21 @@
 <?php
-/*
-Plugin Name: WP101
-Description: A complete set of video tutorials for WordPress, Jetpack, WooCommerce, and Yoast SEO, delivered directly in the dashboard.
-Version: 4.1
-Author: WP101Plugin.com
-Author URI: https://wp101plugin.com/
-Text Domain: wp101
-*/
+/**
+ * Plugin Name: WP101
+ * Plugin URI:  https://wp101plugin.com
+ * Description: A complete set of video tutorials for WordPress, Jetpack, WooCommerce, and Yoast SEO, delivered directly in the dashboard.
+ * Version:     5.0-dev
+ * Author:      WP101
+ * Author URI:  https://wp101.com
+ * Text Domain: wp101
+ *
+ * @package WP101
+ */
 
 define( 'WP101_INC', __DIR__ . '/includes' );
 define( 'WP101_VIEWS', __DIR__ . '/views' );
 define( 'WP101_URL', plugins_url( null, __FILE__ ) );
 define( 'WP101_BASENAME', plugin_basename( __FILE__ ) );
-define( 'WP101_VERSION', '5.0.0' );
+define( 'WP101_VERSION', '5.0.0-dev' );
 
 require_once WP101_INC . '/admin.php';
 require_once WP101_INC . '/class-api.php';


### PR DESCRIPTION
This PR adds [the PHP Compatibility sniffs for PHP_CodeSniffer](https://github.com/wimg/PHPCompatibility), helping to ensure compatibility with PHP >= 5.4.

Fixes #22.