### PR TITLE
Refactor upsell offers

### DIFF
--- a/includes/addons.php
+++ b/includes/addons.php
@@ -84,9 +84,9 @@ function show_notifications( $screen ) {
 			$and  = array_pop( $links );
 			$link = implode( _x( ', ', 'separator for multiple series in a sentence', 'wp101' ), $links );
 			if ( 2 <= count( $links ) ) {
-				$link .= _x( ', ', 'Oxford comma', 'wp101' );
+				$link .= _x( ',', 'Oxford comma', 'wp101' );
 			}
-			$link .= _x( 'and ', 'separator between the last two items in a list', 'wp101' ) . $and;
+			$link .= _x( ' and ', 'separator between the last two items in a list', 'wp101' ) . $and;
 		}
 
 		wp_enqueue_script( 'wp101-addons' );

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -21,7 +21,8 @@ function check_plugins( $previous, $plugins ) {
 		return;
 	}
 
-	$addons    = TemplateTags\api()->get_addons();
+	$api       = TemplateTags\api();
+	$addons    = $api->get_addons();
 	$available = [];
 
 	foreach ( $addons['addons'] as $series ) {
@@ -38,6 +39,12 @@ function check_plugins( $previous, $plugins ) {
 				];
 			}
 		}
+	}
+
+	// Filter out any purchased add-ons.
+	if ( ! empty( $available ) ) {
+		$purchased = wp_list_pluck( $api->get_playlist()['series'], 'slug', 'slug' );
+		$available = array_diff_key( $available, $purchased );
 	}
 
 	update_option( 'wp101-available-series', $available, false );

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -93,7 +93,7 @@ function show_notifications( $screen ) {
 
 		render_notification( sprintf(
 			/* Translators: %1$s is the add-on title(s). */
-			__( 'Get the most out of your site with %1$s from WP101.', 'wp101' ),
+			__( 'Would you like to add the tutorial videos for %1$s from WP101?', 'wp101' ),
 			$link
 		), array_keys( $available ) );
 	} );

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -25,7 +25,7 @@ function check_plugins( $previous, $plugins ) {
 	$available = [];
 
 	foreach ( $addons['addons'] as $series ) {
-		if ( empty( $series['restrictions']['plugins'] ) || $series['includedInSubscription'] ) {
+		if ( empty( $series['restrictions']['plugins'] ) ) {
 			continue;
 		}
 

--- a/tests/test-addons.php
+++ b/tests/test-addons.php
@@ -66,10 +66,10 @@ class AddonTest extends TestCase {
 		$api->shouldReceive( 'get_addons' )
 			->never();
 
-		Addons\check_plugins( null, array(
+		Addons\check_plugins( null, [
 			'some-plugin/some-plugin.php',
 			'another-plugin/another-plugin.php',
-		) );
+		] );
 
 		$this->assertEmpty( get_option( 'wp101-available-series', [] ) );
 	}
@@ -105,9 +105,9 @@ class AddonTest extends TestCase {
 				],
 			] );
 
-		Addons\check_plugins( null, array(
+		Addons\check_plugins( null, [
 			'some-plugin/some-plugin.php',
-		) );
+		] );
 
 		$this->assertEmpty( get_option( 'wp101-available-series', [] ) );
 	}

--- a/tests/test-addons.php
+++ b/tests/test-addons.php
@@ -25,11 +25,12 @@ class AddonTest extends TestCase {
 			->andReturn( [
 				'addons' => [
 					[
-						'title'                  => 'Learning Some Plugin',
-						'slug'                   => 'learning-some-plugin',
-						'url'                    => 'https://wp101plugin.com/series/some-plugin',
-						'includedInSubscription' => false,
-						'restrictions'           => [
+						'title'        => 'Learning Some Plugin',
+						'slug'         => 'learning-some-plugin',
+						'excerpt'      => 'An excerpt',
+						'description'  => 'The full description',
+						'url'          => 'https://wp101plugin.com/series/some-plugin',
+						'restrictions' => [
 							'plugins' => [
 								'some-plugin/some-plugin.php',
 							],
@@ -64,31 +65,6 @@ class AddonTest extends TestCase {
 			'some-plugin/some-plugin.php',
 			'another-plugin/another-plugin.php',
 		) );
-
-		$this->assertEmpty( get_option( 'wp101-available-series', [] ) );
-	}
-
-	public function test_check_plugins_excludes_addons_included_in_subscription() {
-		$api = $this->mock_api();
-		$api->shouldReceive( 'get_addons' )
-			->andReturn( [
-				'addons' => [
-					[
-						'title'                  => 'Learning Some Plugin',
-						'url'                    => 'https://wp101plugin.com/series/some-plugin',
-						'includedInSubscription' => true,
-						'restrictions'           => [
-							'plugins' => [
-								'some-plugin/some-plugin.php',
-							],
-						],
-					],
-				],
-			] );
-
-		Addons\check_plugins( null, [
-			'some-plugin/some-plugin.php',
-		] );
 
 		$this->assertEmpty( get_option( 'wp101-available-series', [] ) );
 	}

--- a/tests/test-addons.php
+++ b/tests/test-addons.php
@@ -38,6 +38,11 @@ class AddonTest extends TestCase {
 					],
 				],
 			] );
+		$api->shouldReceive( 'get_playlist' )
+			->once()
+			->andReturn( [
+				'series' => [],
+			] );
 
 		Addons\check_plugins( null, array(
 			'some-plugin/some-plugin.php',
@@ -64,6 +69,44 @@ class AddonTest extends TestCase {
 		Addons\check_plugins( null, array(
 			'some-plugin/some-plugin.php',
 			'another-plugin/another-plugin.php',
+		) );
+
+		$this->assertEmpty( get_option( 'wp101-available-series', [] ) );
+	}
+
+	public function test_check_plugins_filters_out_purchased_addons() {
+		$api = $this->mock_api();
+		$api->shouldReceive( 'has_api_key' )
+			->andReturn( true );
+		$api->shouldReceive( 'get_addons' )
+			->andReturn( [
+				'addons' => [
+					[
+						'title'        => 'Learning Some Plugin',
+						'slug'         => 'learning-some-plugin',
+						'excerpt'      => 'An excerpt',
+						'description'  => 'The full description',
+						'url'          => 'https://wp101plugin.com/series/some-plugin',
+						'restrictions' => [
+							'plugins' => [
+								'some-plugin/some-plugin.php',
+							],
+						],
+					],
+				],
+			] );
+		$api->shouldReceive( 'get_playlist' )
+			->once()
+			->andReturn( [
+				'series' => [
+					[
+						'slug' => 'learning-some-plugin',
+					],
+				],
+			] );
+
+		Addons\check_plugins( null, array(
+			'some-plugin/some-plugin.php',
 		) );
 
 		$this->assertEmpty( get_option( 'wp101-available-series', [] ) );


### PR DESCRIPTION
This PR addresses some spacing, language, and buried PHP warnings related to the upsell notice that appears on the plugin screen when an add-on is available for an active plugin.

Most importantly, this PR filters out already-purchased add-ons from the notice, so people aren't like "wait, I already have Jetpack, WTF?"

Fixes #26, fixes #28.