### PR TITLE
Smooth out the migration path

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -940,16 +940,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
+                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
                 "shasum": ""
             },
             "require": {
@@ -995,7 +995,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-05-29T13:50:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -2,6 +2,9 @@
 /**
  * Assist subscribers in finding add-ons relevant to their sites.
  *
+ * Note that this file will not be loaded if the user has defined DISABLE_NAG_NOTICES,
+ * so the functionality contained here should be limited to notices about add-ons.
+ *
  * @package WP101
  */
 

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -67,7 +67,7 @@ function wp_config_requires_updating() {
 		return false;
 	}
 
-	return api_key_needs_migration( WP101_API_KEY );
+	return ! WP101_API_KEY || api_key_needs_migration( WP101_API_KEY );
 }
 
 /**

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -131,6 +131,24 @@ class MigrateTest extends TestCase {
 		$this->assertFalse( Migrate\wp_config_requires_updating() );
 	}
 
+	/**
+	 * @requires extension runkit
+	 */
+	public function test_wp_config_requires_updating_with_bad_constant() {
+		define( 'WP101_API_KEY', 'wrong-key' );
+
+		$this->assertTrue( Migrate\wp_config_requires_updating() );
+	}
+
+	/**
+	 * @requires extension runkit
+	 */
+	public function test_wp_config_requires_updating_with_empty_constant() {
+		define( 'WP101_API_KEY', '' );
+
+		$this->assertTrue( Migrate\wp_config_requires_updating() );
+	}
+
 	public function test_render_migration_success_notice() {
 		ob_start();
 		Migrate\render_migration_success_notice();

--- a/tests/test-migrate.php
+++ b/tests/test-migrate.php
@@ -9,10 +9,13 @@ namespace WP101\Tests;
 
 use PHPUnit\Framework\Error\Warning;
 use WP_Error;
+use WP101\Admin as Admin;
 use WP101\Migrate as Migrate;
 
 /**
  * Tests for migrating from older versions of the WP101 plugin.
+ *
+ * @group Migration
  */
 class MigrateTest extends TestCase {
 
@@ -27,6 +30,9 @@ class MigrateTest extends TestCase {
 		remove_all_actions( 'admin_notices' );
 	}
 
+	/**
+	 * If the wp101_api_key option has a legacy key, attempt to exchange it.
+	 */
 	public function test_maybe_migrate() {
 		$api = $this->mock_api();
 		$api->shouldReceive( 'exchange_api_key' )
@@ -59,6 +65,23 @@ class MigrateTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The maybe_migrate() function should return early if there's nothing to migrate.
+	 */
+	public function test_maybe_migrate_returns_early_no_key_is_present() {
+		delete_option( 'wp101_api_key' );
+
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )->never();
+
+		Migrate\maybe_migrate();
+
+		$this->assertFalse( has_action( 'admin_notices' ) );
+	}
+
+	/**
+	 * If an API key already matches the expected pattern, don't attempt to exchange it.
+	 */
 	public function test_maybe_migrate_returns_early_if_keys_do_not_require_migration() {
 		$api = $this->mock_api();
 		$api->shouldReceive( 'exchange_api_key' )->never();
@@ -69,6 +92,9 @@ class MigrateTest extends TestCase {
 		$this->assertFalse( has_action( 'admin_notices' ) );
 	}
 
+	/**
+	 * If we receive a WP_Error while exchanging the key, ensure we handle it properly.
+	 */
 	public function test_maybe_migrate_handles_wp_errors() {
 		$api = $this->mock_api();
 		$api->shouldReceive( 'exchange_api_key' )
@@ -84,69 +110,10 @@ class MigrateTest extends TestCase {
 		$this->assertTrue( has_action( 'admin_notices', 'WP101\Migrate\render_migration_failure_notice' ) );
 	}
 
-	/**
-	 * @dataProvider api_key_provider()
-	 */
-	public function test_api_key_needs_migration( $key, $expected ) {
-		update_option( 'wp101_api_key', $key, false );
-
-		$this->assertEquals( $expected, Migrate\api_key_needs_migration() );
-	}
-
-	/**
-	 * @dataProvider api_key_provider()
-	 */
-	public function test_api_key_needs_migration_with_passed_value( $key, $expected ) {
-		$this->assertEquals( $expected, Migrate\api_key_needs_migration( $key ) );
-	}
-
-	public function api_key_provider() {
-		return [
-			'Legacy API key'  => [ self::LEGACY_API_KEY, true ],
-			'Current API key' => [ self::CURRENT_API_KEY, false ],
-			'Empty API key'   => [ '', false ],
-		];
-	}
-
-	public function test_wp_config_requires_updating_without_constant() {
-		$this->assertFalse( defined( 'WP101_API_KEY' ) );
-		$this->assertFalse( Migrate\wp_config_requires_updating() );
-	}
-
-	/**
-	 * @requires extension runkit
-	 */
-	public function test_wp_config_requires_updating_with_old_constant() {
-		define( 'WP101_API_KEY', self::LEGACY_API_KEY );
-
-		$this->assertTrue( Migrate\wp_config_requires_updating() );
-	}
-
-	/**
-	 * @requires extension runkit
-	 */
-	public function test_wp_config_requires_updating_with_new_constant() {
-		define( 'WP101_API_KEY', self::CURRENT_API_KEY );
-
-		$this->assertFalse( Migrate\wp_config_requires_updating() );
-	}
-
-	/**
-	 * @requires extension runkit
-	 */
-	public function test_wp_config_requires_updating_with_bad_constant() {
-		define( 'WP101_API_KEY', 'wrong-key' );
-
-		$this->assertTrue( Migrate\wp_config_requires_updating() );
-	}
-
-	/**
-	 * @requires extension runkit
-	 */
-	public function test_wp_config_requires_updating_with_empty_constant() {
-		define( 'WP101_API_KEY', '' );
-
-		$this->assertTrue( Migrate\wp_config_requires_updating() );
+	public function test_api_key_needs_migration() {
+		$this->assertTrue( Migrate\api_key_needs_migration( self::LEGACY_API_KEY ) );
+		$this->assertFalse( Migrate\api_key_needs_migration( self::CURRENT_API_KEY ) );
+		$this->assertFalse( Migrate\api_key_needs_migration( '') );
 	}
 
 	public function test_render_migration_success_notice() {
@@ -154,7 +121,7 @@ class MigrateTest extends TestCase {
 		Migrate\render_migration_success_notice();
 		$output = ob_get_clean();
 
-		$this->assertContainsSelector( 'div.notice.notice-success', $output );
+		$this->assertContainsSelector( '#wp101-api-key-upgraded', $output );
 	}
 
 	public function test_render_migration_failure_notice() {
@@ -162,6 +129,56 @@ class MigrateTest extends TestCase {
 		Migrate\render_migration_failure_notice();
 		$output = ob_get_clean();
 
-		$this->assertContainsSelector( 'div.notice.notice-error', $output );
+		$this->assertContainsSelector( '#wp101-api-key-upgrade-failed', $output );
+	}
+
+	/**
+	 * Scenario: An existing subscriber has a (valid) legacy API key saved in wp-config.php.
+	 *
+	 * They should be given instructions on how to update the key, including the new value.
+	 *
+	 * @requires extension runkit
+	 *
+	 * @link https://github.com/liquidweb/wp101plugin/issues/34
+	 */
+	public function test_old_key_requires_migration() {
+		define( 'WP101_API_KEY', self::LEGACY_API_KEY );
+
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )
+			->once()
+			->andReturn( [
+				'apiKey' => self::CURRENT_API_KEY,
+			] );
+
+		Migrate\maybe_migrate();
+
+		$this->assertEquals( self::CURRENT_API_KEY, get_option( 'wp101_api_key' ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', 'WP101\Migrate\render_constant_upgrade_notice' ) );
+	}
+
+	/**
+	 * Scenario: An existing subscriber has a (invalid) legacy API key saved in wp-config.php.
+	 *
+	 * They should be given instructions on how to remove the key.
+	 *
+	 * @requires extension runkit
+	 *
+	 * @link https://github.com/liquidweb/wp101plugin/issues/34
+	 */
+	public function test_invalid_key_needs_removed() {
+		define( 'WP101_API_KEY', 'xxx' );
+
+		$api = $this->mock_api();
+		$api->shouldReceive( 'exchange_api_key' )
+			->once()
+			->andReturn( new WP_Error( 'wp101-api', 'Message from the WP_Error object' ) );
+
+		$this->expectException( Warning::class );
+
+		Migrate\maybe_migrate();
+
+		$this->assertContainsSelector( '#wp101-api-key-constant-remove-notice', $output );
+		$this->assertContains( "'WP101_API_KEY', '" . self::LEGACY_API_KEY . "'", $output );
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -58,7 +58,7 @@ class SettingsTest extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertContainsSelector( '#wp101-api-key', $output );
-		$this->assertContainsSelector( 'div.notice.notice-warning', $output );
+		$this->assertContainsSelector( '#wp101-api-key-constant-upgrade-notice', $output );
 	}
 
 	public function test_public_key_is_cleared_when_private_key_changes() {

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the plugin template tags.
+ * Tests for the plugin settings.
  *
  * @package WP101
  */
@@ -44,21 +44,8 @@ class SettingsTest extends TestCase {
 		Admin\render_settings_page();
 		$output = ob_get_clean();
 
+		$this->assertNotContainsSelector( '#wp101-api-key-set-via-constant-notice', $output );
 		$this->assertNotContainsSelector( '#wp101-api-key', $output );
-	}
-
-	/**
-	 * @requires extension runkit
-	 */
-	public function test_notifies_user_if_constant_needs_replaced() {
-		define( 'WP101_API_KEY', 'some-legacy-api-key' );
-
-		ob_start();
-		Admin\render_settings_page();
-		$output = ob_get_clean();
-
-		$this->assertContainsSelector( '#wp101-api-key', $output );
-		$this->assertContainsSelector( '#wp101-api-key-constant-upgrade-notice', $output );
 	}
 
 	public function test_public_key_is_cleared_when_private_key_changes() {

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -44,7 +44,7 @@ class SettingsTest extends TestCase {
 		Admin\render_settings_page();
 		$output = ob_get_clean();
 
-		$this->assertNotContainsSelector( '#wp101-api-key-set-via-constant-notice', $output );
+		$this->assertContainsSelector( '#wp101-api-key-set-via-constant-notice', $output );
 		$this->assertNotContainsSelector( '#wp101-api-key', $output );
 	}
 

--- a/views/settings.php
+++ b/views/settings.php
@@ -26,7 +26,7 @@ use WP101\TemplateTags as TemplateTags;
 
 			<?php else : ?>
 				<?php if ( Migrate\wp_config_requires_updating() ) : ?>
-					<div class="notice notice-warning">
+					<div id="wp101-api-key-constant-upgrade-notice" class="notice notice-warning">
 						<p><?php esc_html_e( 'Your API key has been updated to work with the latest version of WP101, but your wp-config.php requires updating:', 'wp101' ); ?></p>
 						<ol>
 							<li><?php esc_html_e( 'Open your site\'s wp-config.php file in a text editor.', 'wp101' ); ?></li>

--- a/views/settings.php
+++ b/views/settings.php
@@ -15,35 +15,19 @@ use WP101\TemplateTags as TemplateTags;
 
 	<?php settings_errors(); ?>
 
-	<form method="post" action="options.php">
-		<?php settings_fields( 'wp101' ); ?>
+	<?php if ( defined( 'WP101_API_KEY' ) ) : ?>
+		<div id="wp101-api-key-set-via-constant-notice" class="notice notice-info">
+			<p><strong><?php esc_html_e( 'Your API key is defined in your wp-config.php file.', 'wp101' ); ?></strong></p>
+			<p><?php esc_html_e( 'To make changes, please open your wp-config.php file in a text editor and look for the line that includes:', 'wp101' ); ?></p>
+			<pre><code>define( 'WP101_API_KEY', '...' );</code></pre>
+		</div>
 
-		<section id="api-key">
-			<?php if ( defined( 'WP101_API_KEY' ) && ! Migrate\wp_config_requires_updating( WP101_API_KEY ) ) : ?>
-				<div class="notice notice-info">
-					<p><?php esc_html_e( 'Your API key has been set in your wp-config.php file.', 'wp101' ); ?></p>
-				</div>
+	<?php else : ?>
 
-			<?php else : ?>
-				<?php if ( Migrate\wp_config_requires_updating() ) : ?>
-					<div id="wp101-api-key-constant-upgrade-notice" class="notice notice-warning">
-						<p><?php esc_html_e( 'Your API key has been updated to work with the latest version of WP101, but your wp-config.php requires updating:', 'wp101' ); ?></p>
-						<ol>
-							<li><?php esc_html_e( 'Open your site\'s wp-config.php file in a text editor.', 'wp101' ); ?></li>
-							<li>
-								<?php
-									echo wp_kses_post( sprintf(
-										/* Translators: %1$s is a code snippet for "define( 'WP101_API_KEY', '...' );" in wp-config.php. */
-										__( 'Find the line that reads %1$s and either remove it completely or replace it with the following:', 'wp101' ),
-										sprintf( "<code>define( 'WP101_API_KEY', '%s' );</code>", WP101_API_KEY )
-									) );
-								?>
-								<pre><code>define( 'WP101_API_KEY', '<?php echo esc_html( TemplateTags\get_api_key() ); ?>' );</code></pre>
-							</li>
-							<li><?php esc_html_e( 'Save the wp-config.php file on your web server.', 'wp101' ); ?></li>
-					</div>
-				<?php endif; ?>
+		<form method="post" action="options.php">
+			<?php settings_fields( 'wp101' ); ?>
 
+			<section id="api-key">
 				<h2><?php echo esc_html( _x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ) ); ?></h2>
 				<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
 				<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>
@@ -56,9 +40,9 @@ use WP101\TemplateTags as TemplateTags;
 						<input name="wp101_api_key" id="wp101-api-key" type="text" value="<?php echo esc_attr( TemplateTags\get_api_key() ); ?>" class="regular-text code" />
 					</td>
 				</table>
-			<?php endif; ?>
-		</section>
 
-		<?php submit_button(); ?>
-	</form>
+			</section>
+			<?php submit_button(); ?>
+		</form>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
This PR addresses some issues we've run into when testing migration from legacy API keys. Now, when upgrading legacy API keys, the process looks something like this:

1. Is there a `WP101_API_KEY` constant set in wp-config.php and, if so, can we use it in an exchange (e.g. is it non-empty)?
    - If we can't use it, bail on the exchange and tell the user what's wrong.
2. If we have a non-empty API key (either via constant or wp_options), does it match the format of current keys?
    - If so, return early and assume all is well — users will get error messages if their API key is invalid.
3. Attempt to exchange the API key — if we get one back from the exchange but `WP101_API_KEY` is set in the wp-config.php file, give the user instructions on how to remove or replace it.

This PR also adds explicit IDs to the rendered notifications, making our tests better at asserting we're seeing the messaging we expect, as well as fixing some inline documentation issues.

Fixes #34.