### PR TITLE
Indicate hidden series

### DIFF
--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -164,7 +164,15 @@ class API {
 		$api_key = $this->get_public_api_key();
 
 		array_walk( $response['addons'], function ( &$addon ) use ( $api_key ) {
-			$addon['url'] = add_query_arg( 'apiKey', $api_key, $addon['url'] );
+			$addon['url']                = add_query_arg( 'apiKey', $api_key, $addon['url'] );
+			$addon['meets_requirements'] = true;
+
+			// Does the current site configuration meet requirements?
+			if ( ! empty( $addon['restrictions']['plugins'] ) ) {
+				$requirements = array_filter( $addon['restrictions']['plugins'], 'is_plugin_active' );
+
+				$addon['meets_requirements'] = ! empty( $requirements );
+			}
 		} );
 
 		return $response;

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -130,6 +130,69 @@ class AdminTest extends TestCase {
 	}
 
 	/**
+	 * @link https://github.com/liquidweb/wp101plugin/issues/40
+	 */
+	public function test_render_addons_page_indicates_when_available_series_are_visible() {
+		$api = $this->mock_api();
+		$api->shouldReceive( 'get_playlist' )
+			->andReturn( [
+				'series' => [
+					[
+						'slug' => 'example-series',
+					],
+				],
+			] );
+		$api->shouldReceive( 'get_addons' )
+			->andReturn( [
+				'addons' => [
+					[
+						'title'              => 'Example Series',
+						'slug'               => 'example-series',
+						'meets_requirements' => true,
+					],
+				]
+			] );
+
+		ob_start();
+		Admin\render_addons_page();
+		$output = ob_get_clean();
+
+		$this->assertContains( get_admin_url( null, 'admin.php?page=wp101' ), $output );
+	}
+
+	/**
+	 * @link https://github.com/liquidweb/wp101plugin/issues/40
+	 */
+	public function test_render_addons_page_indicates_when_available_series_are_hidden() {
+		$api = $this->mock_api();
+		$api->shouldReceive( 'get_playlist' )
+			->andReturn( [
+				'series' => [
+					[
+						'slug' => 'example-series',
+					],
+				],
+			] );
+		$api->shouldReceive( 'get_addons' )
+			->andReturn( [
+				'addons' => [
+					[
+						'title'              => 'Example Series',
+						'slug'               => 'example-series',
+						'meets_requirements' => false,
+					],
+				]
+			] );
+
+		ob_start();
+		Admin\render_addons_page();
+		$output = ob_get_clean();
+
+		$this->assertNotContains( get_admin_url( null, 'admin.php?page=wp101' ), $output );
+		$this->assertContains( 'notice-info', $output );
+	}
+
+	/**
 	 * Retrieve the WP101 menu node(s) visible for the current user.
 	 *
 	 * @return array

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -203,6 +203,53 @@ class ApiTest extends TestCase {
 		);
 	}
 
+	public function test_get_addons_updates_adds_meets_requirements() {
+		update_option( 'active_plugins', [
+			'some-plugin/some-plugin.php',
+		] );
+
+		$this->set_expected_response([
+			'body' => wp_json_encode( [
+				'status' => 'success',
+				'data'   => [
+					'addons' => [
+						[
+							'url'          => 'http://example.com',
+							'restrictions' => [
+								'plugins' => [
+									'some-plugin/some-plugin.php',
+								],
+							],
+						],
+						[
+							'url'          => 'http://example.com',
+							'restrictions' => [
+								'plugins' => [
+									'some-other-plugin/some-other-plugin.php',
+								],
+							],
+						],
+						[
+							'url'          => 'http://example.com',
+							'restrictions' => [
+								'plugins' => [
+									'some-plugin/some-plugin.php',
+									'some-other-plugin/some-other-plugin.php',
+								],
+							],
+						],
+					],
+				],
+			] ),
+		]);
+
+		$this->assertTrue( API::get_instance()->get_addons()['addons'][0]['meets_requirements'] );
+		$this->assertFalse( API::get_instance()->get_addons()['addons'][1]['meets_requirements'] );
+
+		// If multiple requirements are listed, only one must be met.
+		$this->assertTrue( API::get_instance()->get_addons()['addons'][2]['meets_requirements'] );
+	}
+
 	public function test_get_playlist() {
 		$json = [
 			'status' => 'success',

--- a/views/add-ons.php
+++ b/views/add-ons.php
@@ -47,14 +47,21 @@ use WP101\TemplateTags as TemplateTags;
 						<?php TemplateTags\list_topics( $addon['topics'], 3, $addon['url'] ); ?>
 					<?php endif; ?>
 
-					<p class="wp101-addon-button">
-						<?php if ( $has_addon ) : ?>
+					<?php if ( $has_addon && $addon['meets_requirements'] ) : ?>
+						<p class="wp101-addon-button">
 							<a href="<?php echo esc_url( admin_url( 'admin.php?page=wp101' ) ); ?>" class="button button-secondary"><?php echo esc_html_e( 'Watch Videos', 'wp101' ); ?></a>
+						</p>
 
-						<?php elseif ( ! empty( $addon['url'] ) ) : ?>
+					<?php elseif ( $has_addon ) : ?>
+						<div class="notice notice-info inline">
+							<p><?php esc_html_e( 'Your WP101 Plugin subscription includes access to this course, but it looks like it might not be useful on this site.', 'wp101' ); ?></p>
+						</div>
+
+					<?php elseif ( ! empty( $addon['url'] ) ) : ?>
+						<p class="wp101-addon-button">
 							<a href="<?php echo esc_url( $addon['url'] ); ?>" class="button button-primary" target="_blank"><?php echo esc_html_e( 'Get Add-on', 'wp101' ); ?></a>
-						<?php endif; ?>
-					</p>
+						</p>
+					<?php endif; ?>
 				</div>
 
 			<?php endforeach; ?>

--- a/views/add-ons.php
+++ b/views/add-ons.php
@@ -47,7 +47,7 @@ use WP101\TemplateTags as TemplateTags;
 						<?php TemplateTags\list_topics( $addon['topics'], 3, $addon['url'] ); ?>
 					<?php endif; ?>
 
-					<?php if ( $has_addon && $addon['meets_requirements'] ) : ?>
+					<?php if ( $has_addon && isset( $addon['meets_requirements'] ) && (bool) $addon['meets_requirements'] ) : ?>
 						<p class="wp101-addon-button">
 							<a href="<?php echo esc_url( admin_url( 'admin.php?page=wp101' ) ); ?>" class="button button-secondary"><?php echo esc_html_e( 'Watch Videos', 'wp101' ); ?></a>
 						</p>

--- a/views/add-ons.php
+++ b/views/add-ons.php
@@ -47,7 +47,7 @@ use WP101\TemplateTags as TemplateTags;
 						<?php TemplateTags\list_topics( $addon['topics'], 3, $addon['url'] ); ?>
 					<?php endif; ?>
 
-					<?php if ( $has_addon && isset( $addon['meets_requirements'] ) && (bool) $addon['meets_requirements'] ) : ?>
+					<?php if ( $has_addon && ! empty( $addon['meets_requirements'] ) ) : ?>
 						<p class="wp101-addon-button">
 							<a href="<?php echo esc_url( admin_url( 'admin.php?page=wp101' ) ); ?>" class="button button-secondary"><?php echo esc_html_e( 'Watch Videos', 'wp101' ); ?></a>
 						</p>

--- a/views/listings.php
+++ b/views/listings.php
@@ -22,14 +22,15 @@ $query_args = array(
 		<?php echo esc_html_x( 'WordPress Video Tutorials', 'listings page title', 'wp101' ); ?>
 	</h1>
 
-	<main class="wp101-media">
-		<h2 id="wp101-player-title"></h2>
-		<div class="wp101-player-wrap">
-			<iframe id="wp101-player" allowfullscreen></iframe>
-		</div>
-	</main>
-
 	<?php if ( ! empty( $playlist['series'] ) ) : ?>
+
+		<main class="wp101-media">
+			<h2 id="wp101-player-title"></h2>
+			<div class="wp101-player-wrap">
+				<iframe id="wp101-player" allowfullscreen></iframe>
+			</div>
+		</main>
+
 		<nav class="wp101-playlist card">
 			<?php foreach ( $playlist['series'] as $series ) : ?>
 
@@ -72,5 +73,10 @@ $query_args = array(
 				</div>
 			<?php endif; ?>
 		</nav>
+
+	<?php else : ?>
+
+		<p><?php esc_html_e( 'There was a problem retrieving content from WP101plugin.com.', 'wp101' ); ?></p>
+
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
If a subscriber has access to a given series but the site doesn't use the corresponding plugins (think "I can access the Jetpack series, but I don't use Jetpack"), then show a message to indicate why the videos aren't being shown.

Fixes #40.