### PR TITLE
Hide add-ons when not applicable

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -99,14 +99,18 @@ function register_menu_pages() {
 		__NAMESPACE__ . '\render_settings_page'
 	);
 
-	add_submenu_page(
-		'wp101',
-		_x( 'WP101 Add-ons', 'page title', 'wp101' ),
-		_x( 'Add-ons', 'menu title', 'wp101' ),
-		get_addon_capability(),
-		'wp101-addons',
-		__NAMESPACE__ . '\render_addons_page'
-	);
+	$addons = TemplateTags\api()->get_addons();
+
+	if ( ! empty( $addons['addons'] ) ) {
+		add_submenu_page(
+			'wp101',
+			_x( 'WP101 Add-ons', 'page title', 'wp101' ),
+			_x( 'Add-ons', 'menu title', 'wp101' ),
+			get_addon_capability(),
+			'wp101-addons',
+			__NAMESPACE__ . '\render_addons_page'
+		);
+	}
 }
 add_action( 'admin_menu', __NAMESPACE__ . '\register_menu_pages' );
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -141,7 +141,7 @@ class API {
 	 * @return array An array of all available add-ons.
 	 */
 	public function get_addons() {
-		$response = $this->send_request( 'GET', '/add-ons' );
+		$response = $this->send_request( 'GET', '/add-ons', [], [], 12 * HOUR_IN_SECONDS );
 
 		if ( is_wp_error( $response ) ) {
 			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -81,7 +81,17 @@ class AdminTest extends TestCase {
 			'role' => 'administrator',
 		] ) );
 
-		$this->set_api_key();
+		$api = $this->mock_api();
+		$api->set_api_key( md5( uniqid() ) );
+		$api->shouldReceive( 'get_addons' )
+			->once()
+			->andReturn( [
+				'addons' => [
+					[
+						'slug' => 'some-add-on',
+					],
+				],
+			] );
 
 		$menu = $this->get_menu_items();
 
@@ -110,6 +120,25 @@ class AdminTest extends TestCase {
 		$menu = $this->get_menu_items();
 
 		$this->assertEquals( 'wp101-settings', $menu['parent'][2], 'Expected "wp101-settings" as the menu slug.' );
+	}
+
+	public function test_register_menu_pages_hides_empty_addon_pages() {
+		wp_set_current_user( $this->factory()->user->create( [
+			'role' => 'administrator',
+		] ) );
+
+		$api = $this->mock_api();
+		$api->set_api_key( md5( uniqid() ) );
+		$api->shouldReceive( 'get_addons' )
+			->once()
+			->andReturn( [
+				'addons' => [],
+			] );
+
+		$menu = $this->get_menu_items();
+
+		$this->assertCount( 2, $menu['children'] );
+		$this->assertEmpty( menu_page_url( 'wp101-addons', false ) );
 	}
 
 	public function test_register_settings() {

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -49,10 +49,11 @@ class TestCase extends WP_UnitTestCase {
 	 * @after
 	 */
 	public function reset_menus() {
-		global $menu, $submenu;
+		global $menu, $submenu, $_parent_pages;
 
-		$menu    = null;
-		$submenu = null;
+		$menu          = null;
+		$submenu       = null;
+		$_parent_pages = [];
 	}
 
 	/**

--- a/views/listings.php
+++ b/views/listings.php
@@ -14,6 +14,7 @@ $query_args = array(
 	'apiKey' => $public_key,
 	'host'   => site_url(),
 );
+$addons     = $api->get_addons();
 
 ?>
 
@@ -64,7 +65,7 @@ $query_args = array(
 
 			<?php endforeach; ?>
 
-			<?php if ( TemplateTags\current_user_can_purchase_addons() ) : ?>
+			<?php if ( TemplateTags\current_user_can_purchase_addons() && ! empty( $addons['addons'] ) ) : ?>
 				<div class="wp101-addon-notice">
 					<h2><?php echo esc_html_e( 'More from WP101', 'wp101' ); ?></h2>
 					<p><?php esc_html_e( 'Get the most out of WP101 with even more content!', 'wp101' ); ?></p>


### PR DESCRIPTION
When a subscriber has a plan that doesn't have any add-ons for sale (for instance, the "Solo" plan), there's no reason to waste their time with the "Add-ons" page within WP Admin.

Fixes #36.