### PR TITLE
Better error messaging when a playlist is empty or domain validation fails

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -163,6 +163,9 @@ function render_listings_page() {
 	$playlist   = $api->get_playlist();
 	$public_key = $api->get_public_api_key();
 
+	// Filter out irrelevant series.
+	$playlist['series'] = array_filter( $playlist['series'], __NAMESPACE__ . '\is_relevant_series' );
+
 	include WP101_VIEWS . '/listings.php';
 }
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -188,3 +188,29 @@ function clear_public_api_key() {
 	TemplateTags\api()->get_public_api_key();
 }
 add_action( 'update_option_wp101_api_key', __NAMESPACE__ . '\clear_public_api_key' );
+
+/**
+ * Determine whether or not a series is relevant to the current site.
+ *
+ * Relevancy is determined based on two factors:
+ *
+ * 1. Does the series define any specific requirements?
+ * 2. If so, does this site meet those requirements?
+ *
+ * For example, a series about Jetpack might specify that it should only be displayed on sites
+ * running Jetpack — if a site doesn't have Jetpack installed and activated, don't bother
+ * displaying the series.
+ *
+ * @param array $series The series object, as returned from the API.
+ *
+ * @return bool Whether or not the series should be displayed.
+ */
+function is_relevant_series( $series ) {
+	if ( ! isset( $series['restrictions']['plugins'] ) || empty( $series['restrictions']['plugins'] ) ) {
+		return true;
+	}
+
+	$restrictions = array_filter( $series['restrictions']['plugins'], 'is_plugin_active' );
+
+	return ! empty( $restrictions );
+}

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -129,6 +129,75 @@ class AdminTest extends TestCase {
 		$this->assertContains( get_admin_url( null, 'admin.php?page=wp101' ), $actions['settings'] );
 	}
 
+	public function test_is_relevant_series_without_restrictions() {
+		$series = [
+			'restrictions' => [
+				'plugins' => [],
+			],
+		];
+
+		$this->assertTrue(
+			Admin\is_relevant_series( $series ),
+			'Series without restrictions are always relevant.'
+		);
+	}
+
+	public function test_is_relevant_series_with_unmet_restrictions() {
+		$series = [
+			'restrictions' => [
+				'plugins' => [
+					'some-plugin/some-plugin.php',
+					'some-other-plugin/some-other-plugin.php',
+				],
+			],
+		];
+
+		update_option( 'active_plugins', [] );
+
+		$this->assertFalse(
+			Admin\is_relevant_series( $series ),
+			'If requirements aren\'t met, the series is not relevant.'
+		);
+	}
+
+	public function test_is_relevant_series_with_some_met_restrictions() {
+		$series = [
+			'restrictions' => [
+				'plugins' => [
+					'some-plugin/some-plugin.php',
+					'some-other-plugin/some-other-plugin.php',
+				],
+			],
+		];
+
+		update_option( 'active_plugins', [
+			'some-plugin/some-plugin.php',
+		] );
+
+		$this->assertTrue(
+			Admin\is_relevant_series( $series ),
+			'Only meeting a single requirement is necessary for relevancy.'
+		);
+	}
+
+	public function test_is_relevant_series_with_all_met_restrictions() {
+		$series = [
+			'restrictions' => [
+				'plugins' => [
+					'some-plugin/some-plugin.php',
+					'some-other-plugin/some-other-plugin.php',
+				],
+			],
+		];
+
+		update_option( 'active_plugins', [
+			'some-plugin/some-plugin.php',
+			'some-other-plugin/some-other-plugin.php',
+		] );
+
+		$this->assertTrue( Admin\is_relevant_series( $series ) );
+	}
+
 	/**
 	 * Retrieve the WP101 menu node(s) visible for the current user.
 	 *

--- a/views/listings.php
+++ b/views/listings.php
@@ -33,23 +33,6 @@ $query_args = array(
 
 		<nav class="wp101-playlist card">
 			<?php foreach ( $playlist['series'] as $series ) : ?>
-
-				<?php
-
-				/*
-				 * Potentially skip over a series if there are restrictions which the current site
-				 * does not meet (e.g. "don't show Jetpack videos on a site not running Jetpack.").
-				 */
-				if ( ! empty( $series['restrictions'] ) && ! empty( $series['restrictions']['plugins'] ) ) {
-					$restrictions = array_filter( $series['restrictions']['plugins'], 'is_plugin_active' );
-
-					if ( empty( $restrictions ) ) {
-						continue;
-					}
-				} elseif ( empty( $series['topics'] ) ) {
-					continue;
-				}
-				?>
 				<div class="wp101-series">
 					<h2><?php echo esc_html( $series['title'] ); ?></h2>
 					<ol class="wp101-topics-list">

--- a/views/listings.php
+++ b/views/listings.php
@@ -59,7 +59,22 @@ $query_args = array(
 
 	<?php else : ?>
 
-		<p><?php esc_html_e( 'There was a problem retrieving content from WP101plugin.com.', 'wp101' ); ?></p>
+		<div class="notice notice-error">
+			<p><strong><?php esc_html_e( 'There was a problem retrieving content from WP101plugin.com.', 'wp101' ); ?></strong></p>
+			<p>
+				<?php
+				if ( current_user_can( 'manage_options' ) ) {
+					echo wp_kses_post( sprintf(
+						/* Translators: %1$s is the "WP101 Settings" admin page. */
+						__( '<a href="%1$s">Please verify your API key</a> and ensure your WP101plugin.com account has access to the desired content.', 'wp101' ),
+						esc_url( menu_page_url( 'wp101-settings', false ) )
+					) );
+				} else {
+					esc_html_e( 'Please contact a site administrator for further assistance.', 'wp101' );
+				}
+				?>
+			</p>
+		</div>
 
 	<?php endif; ?>
 </div>

--- a/views/listings.php
+++ b/views/listings.php
@@ -22,14 +22,15 @@ $query_args = array(
 		<?php echo esc_html_x( 'WordPress Video Tutorials', 'listings page title', 'wp101' ); ?>
 	</h1>
 
-	<main class="wp101-media">
-		<h2 id="wp101-player-title"></h2>
-		<div class="wp101-player-wrap">
-			<iframe id="wp101-player" allowfullscreen></iframe>
-		</div>
-	</main>
-
 	<?php if ( ! empty( $playlist['series'] ) ) : ?>
+
+		<main class="wp101-media">
+			<h2 id="wp101-player-title"></h2>
+			<div class="wp101-player-wrap">
+				<iframe id="wp101-player" allowfullscreen></iframe>
+			</div>
+		</main>
+
 		<nav class="wp101-playlist card">
 			<?php foreach ( $playlist['series'] as $series ) : ?>
 
@@ -72,5 +73,10 @@ $query_args = array(
 				</div>
 			<?php endif; ?>
 		</nav>
+
+	<?php else : ?>
+
+		<p><?php esc_html_e( 'There was a problem retrieving content from WP101plugin.com.', 'wp101' ); ?></p>
+
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
This PR adds checks for an empty playlist and, if one is found (either due to API keys being rejected or no relevant topics being visible), the user is given more useful error messaging than simply "There was a problem retrieving content from WP101plugin.com."

Fixes #38, fixes #37.