### PR TITLE
Handle missing series + topics when rendering shortcode

### DIFF
--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -55,10 +55,26 @@ function render_shortcode( $atts ) {
 	if ( $atts['series'] ) {
 		$series = TemplateTags\get_series( $atts['series'] );
 
+		if ( false === $series ) {
+			return shortcode_debug( sprintf(
+				/* Translators: %1$s is the series slug. */
+				__( 'Series "%1$s" was not found.', 'wp101' ),
+				$atts['series']
+			) );
+		}
+
 		return render_shortcode_playlist( $series );
 
 	} elseif ( $atts['video'] ) {
 		$topic = TemplateTags\get_topic( $atts['video'] );
+
+		if ( false === $topic ) {
+			return shortcode_debug( sprintf(
+				/* Translators: %1$s is the video slug. */
+				__( 'Video "%1$s" was not found.', 'wp101' ),
+				$atts['video']
+			) );
+		}
 
 		return render_shortcode_single( $topic );
 	}

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -45,6 +45,26 @@ class ShortcodeTest extends TestCase {
 		$this->assertTrue( wp_style_is( 'wp101', 'enqueued' ), 'Expected the styles to be enqueued.' );
 	}
 
+	public function test_handles_missing_series() {
+		wp_set_current_user( $this->factory()->user->create() );
+
+		$post = $this->factory()->post->create( [
+			'post_status' => 'private',
+		] );
+		$api  = $this->mock_api();
+
+		$api->shouldReceive( 'account_can' )->andReturn( true );
+		$api->shouldReceive( 'get_series' )->andReturn( false );
+
+		$this->go_to( get_permalink( $post ) );
+
+		$this->assertEmpty(
+			Shortcode\render_shortcode( [
+				'series' => 'test-series',
+			] )
+		);
+	}
+
 	public function test_can_show_topic() {
 		wp_set_current_user( $this->factory()->user->create() );
 		Shortcode\register_scripts_styles();
@@ -72,6 +92,26 @@ class ShortcodeTest extends TestCase {
 			] )
 		);
 		$this->assertTrue( wp_style_is( 'wp101', 'enqueued' ), 'Expected the styles to be enqueued.' );
+	}
+
+	public function test_handles_missing_topic() {
+		wp_set_current_user( $this->factory()->user->create() );
+
+		$post = $this->factory()->post->create( [
+			'post_status' => 'private',
+		] );
+		$api  = $this->mock_api();
+
+		$api->shouldReceive( 'account_can' )->andReturn( true );
+		$api->shouldReceive( 'get_topic' )->andReturn( false );
+
+		$this->go_to( get_permalink( $post ) );
+
+		$this->assertEmpty(
+			Shortcode\render_shortcode( [
+				'video' => 'test-topic',
+			] )
+		);
 	}
 
 	public function test_gives_precedence_to_series_over_videos() {


### PR DESCRIPTION
Depending on whether a "series" or "video" attribute are passed to the [wp101] shortcode (with precedence being given to the first), the shortcode will render either a playlist or a single video.

Unfortunately, if the given series and/or video doesn't exist, the shortcode was previously generating an error. This commit ensures that we're explicitly checking for values before attempting to display them, and showing a debug message to logged-in users who might need to troubleshoot.