### PR TITLE
Exclude the dist/ directory from PHP_CodeSniffer

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,6 +15,7 @@
 
 	<!-- FILES -->
 	<exclude-pattern>assets/*</exclude-pattern>
+	<exclude-pattern>dist/*</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>tests/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>


### PR DESCRIPTION
When running PHP_CodeSniffer in an environment that's been used to build the plugin (via `grunt build`), don't bother scanning the dist/ directory.