### PR TITLE
Ensure public API keys are refreshed using new private keys

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -191,8 +191,10 @@ function render_settings_page() {
 function clear_public_api_key() {
 	delete_option( API::PUBLIC_API_KEY_OPTION );
 
-	// Prime the cache with the new key.
-	TemplateTags\api()->get_public_api_key();
+	// Prime the cache with the new public + private keys.
+	$api = TemplateTags\api();
+	$api->clear_api_key();
+	$api->get_public_api_key();
 }
 add_action( 'update_option_wp101_api_key', __NAMESPACE__ . '\clear_public_api_key' );
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -105,6 +105,13 @@ class API {
 	}
 
 	/**
+	 * Clear the current value for $this->api_key.
+	 */
+	public function clear_api_key() {
+		$this->api_key = null;
+	}
+
+	/**
 	 * Retrieve the public API key from WP101.
 	 *
 	 * Public API keys are generated on a per-domain basis by the WP101 API, and thus are safe for

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -66,6 +66,15 @@ class ApiTest extends TestCase {
 		$this->assertEquals( $key, $api->get_api_key() );
 	}
 
+	public function test_clear_api_key() {
+		$api = API::get_instance();
+
+		$api->set_api_key( md5( uniqid() ) );
+		$api->clear_api_key();
+
+		$this->assertNull( $api->get_api_key() );
+	}
+
 	public function test_has_api_key() {
 		$api = API::get_instance();
 

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -52,6 +52,10 @@ class SettingsTest extends TestCase {
 		update_option( 'wp101_api_key', md5( uniqid() ) );
 		update_option( API::PUBLIC_API_KEY_OPTION, uniqid() );
 
+		$api = $this->mock_api();
+		$api->shouldReceive( 'clear_api_key' )->once();
+		$api->shouldReceive( 'get_public_api_key' )->once();
+
 		// Change the private key.
 		update_option( 'wp101_api_key', md5( uniqid() ) );
 


### PR DESCRIPTION
This PR addresses an issue we'd regularly hit during testing, when we'd change an API key (for example, moving from testing a Solo plan to a Small Business plan), but then the media would start failing.

As the private API key is stored via the WP Settings API, we have to listen for changes to the private API key via `WP101\Admin\clear_public_api_key()`; unfortunately, if an API request had already been made (chances are one would have), the Singleton's `$api_key` property would already be primed, so the plugin would delete the public API option, then attempt to get the public key for the **old** private key.

Now, `API::clear_api_key()` is called before attempting to retrieve the public key. This references #39 (and removes the urgency of it), but doesn't flush *all* caches.