### PR TITLE
Clean up the add-ons page styles

### DIFF
--- a/assets/css/scss/partials/_addons.scss
+++ b/assets/css/scss/partials/_addons.scss
@@ -15,11 +15,10 @@
 		flex-wrap: nowrap;
 		flex-direction: column;
 		justify-content: flex-start;
-		flex: 1;
 		margin-right: 20px;
 	}
 
-	.wp101-addon-button {
+	.wp101-addon-button, .notice {
 		align-self: flex-end;
 		margin-top: auto;
 	}


### PR DESCRIPTION
This commit cleans up the Flexbox implementation to create a better appearance on the add-ons page.

**Before:**
![screen shot 2018-06-21 at 3 28 20 pm](https://user-images.githubusercontent.com/233836/41741086-14536ff2-7568-11e8-8085-be6339543d75.png)

**After:**
![screen shot 2018-06-21 at 3 28 16 pm](https://user-images.githubusercontent.com/233836/41741095-19636588-7568-11e8-9c8b-dd32d698f92c.png)
