### PR TITLE
Mask the API key on the settings screen

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,8 @@ module.exports = function(grunt) {
 						'assets/js/src/addons.js'
 					],
 					'assets/js/wp101-admin.min.js': [
-						'assets/js/src/playlist.js'
+						'assets/js/src/playlist.js',
+						'assets/js/src/settings.js'
 					]
 				}
 			}

--- a/assets/js/src/settings.js
+++ b/assets/js/src/settings.js
@@ -32,6 +32,7 @@
 
 			settingsDisplay.setAttribute('hidden', '');
 			settingsForm.removeAttribute('hidden');
+			document.getElementById('wp101-api-key').focus();
 		});
 	}
 }());

--- a/assets/js/src/settings.js
+++ b/assets/js/src/settings.js
@@ -1,0 +1,37 @@
+/**
+ * Scripts for the WP101 settings screen within WP Admin.
+ *
+ * @package WP101
+ */
+
+(function () {
+	'use strict';
+
+	var settingsForm = document.getElementById('wp101-settings-api-key-form'),
+		settingsDisplay = document.getElementById('wp101-settings-api-key-display');
+
+	// Abort if we're not on the WP101 Settings screen.
+	if (! settingsForm) {
+		return;
+	}
+
+	/*
+	 * If an API key has already been set, we'll display a masked version.
+	 *
+	 * Clicking the button within settingsDisplay will replace the display with the previously-
+	 * hidden form.
+	 */
+	if (settingsDisplay && settingsForm.classList.contains('hide-if-js')) {
+		settingsForm.setAttribute('hidden', '');
+		settingsForm.classList.remove('hide-if-js');
+
+		settingsDisplay.addEventListener('click', function (e) {
+			if ('BUTTON' !== e.target.tagName) {
+				return;
+			}
+
+			settingsDisplay.setAttribute('hidden', '');
+			settingsForm.removeAttribute('hidden');
+		});
+	}
+}());

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -138,11 +138,44 @@ add_action( 'plugin_action_links_' . WP101_BASENAME, __NAMESPACE__ . '\plugin_se
 function register_settings() {
 	register_setting( 'wp101', 'wp101_api_key', [
 		'description'       => _x( 'The key used to authenticate with WP101plugin.com.', 'wp101' ),
-		'sanitize_callback' => 'sanitize_text_field',
+		'sanitize_callback' => __NAMESPACE__ . '\sanitize_api_key',
 		'show_in_rest'      => false,
 	] );
 }
 add_action( 'admin_init', __NAMESPACE__ . '\register_settings' );
+
+/**
+ * Sanitize callback for the wp101_api_key setting.
+ *
+ * @param string $key The provided API key.
+ *
+ * @return string The sanitized key.
+ */
+function sanitize_api_key( $key ) {
+	$key = sanitize_text_field( $key );
+	$api = TemplateTags\api();
+	$api->set_api_key( $key );
+
+	// If the key is valid, inform the user.
+	if ( $api->get_account() ) {
+		add_settings_error( 'wp101', 'api_key', sprintf(
+
+			/*
+			 * Translators: %1$s is a confirmation message, %2$s is the playlist page URL, and %3$s
+			 * is the link anchor text.
+			 */
+			'%1$s <a href="%2$s">%3$s</a>',
+			esc_html__( 'Your API key ready to go:', 'wp101' ),
+			esc_attr( get_admin_url( null, 'admin.php?page=wp101' ) ),
+			esc_html__( 'start watching video tutorials!', 'wp101' )
+		), 'updated' );
+	} else {
+		add_settings_error( 'wp101', 'api_key', __( 'Invalid API key!', 'wp101' ), 'error' );
+		$key = '';
+	}
+
+	return $key;
+}
 
 /**
  * Render the WP101 add-ons page.

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -112,12 +112,27 @@ class API {
 	}
 
 	/**
+	 * Retrieve an *uncached* response from the /account endpoint.
+	 *
+	 * @return array An array of all account attributes or an empty array if no account was found.
+	 */
+	public function get_account() {
+		$response = $this->send_request( 'GET', '/account' );
+
+		if ( is_wp_error( $response ) ) {
+			return [];
+		}
+
+		return $response;
+	}
+
+	/**
 	 * Retrieve the public API key from WP101.
 	 *
 	 * Public API keys are generated on a per-domain basis by the WP101 API, and thus are safe for
 	 * using client-side without fear of compromising the private key.
 	 *
-	 * @return string The public API key.
+	 * @return string|WP_Error The public API key or any WP_Error that occurred.
 	 */
 	public function get_public_api_key() {
 		$public_key = get_option( self::PUBLIC_API_KEY_OPTION );

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -148,7 +148,7 @@ class AdminTest extends TestCase {
 
 		$this->assertArrayHasKey( 'wp101_api_key', $settings );
 		$this->assertEquals( 'wp101', $settings['wp101_api_key']['group'] );
-		$this->assertEquals( 'sanitize_text_field', $settings['wp101_api_key']['sanitize_callback'] );
+		$this->assertEquals( 'WP101\Admin\sanitize_api_key', $settings['wp101_api_key']['sanitize_callback'] );
 		$this->assertFalse( $settings['wp101_api_key']['show_in_rest'], 'The API key should never be exposed via the WP REST API.' );
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -85,6 +85,36 @@ class ApiTest extends TestCase {
 		$this->assertTrue( $api->has_api_key() );
 	}
 
+	public function test_get_account() {
+		$json = [
+			'status' => 'success',
+			'data'   => [
+				'publicKey' => uniqid(),
+			],
+		];
+
+		$this->set_expected_response( [
+			'body' => wp_json_encode( $json ),
+		] );
+
+		$this->assertEquals(
+			$json['data'],
+			API::get_instance()->get_account(),
+			'The account node should be returned.'
+		);
+	}
+
+	public function test_get_account_suppresses_wp_errors() {
+		$this->set_expected_response( function () {
+			return new WP_Error( 'msg' );
+		} );
+
+		$this->assertEmpty(
+			API::get_instance()->get_account(),
+			'If an error occurs, get_account() should return an empty array.'
+		);
+	}
+
 	public function test_get_public_api_key() {
 		$this->assertFalse( get_option( API::PUBLIC_API_KEY_OPTION ) );
 

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -36,7 +36,8 @@ class SettingsTest extends TestCase {
 	}
 
 	public function test_hides_api_key_form_if_already_set() {
-		$key = $this->set_api_key();
+		$key    = $this->set_api_key();
+		$masked = substr( $key, 0, 4 );
 
 		ob_start();
 		Admin\render_settings_page();
@@ -54,6 +55,11 @@ class SettingsTest extends TestCase {
 			[
 				'id'    => 'wp101-settings-api-key-display',
 			],
+			$output
+		);
+
+		$this->assertRegExp(
+			'/\<code\>' . preg_quote( substr( $key, 0, 4 ) ) . '(&#9679;)+\<\/code\>/',
 			$output
 		);
 

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -16,6 +16,26 @@ use WP101\API;
 class SettingsTest extends TestCase {
 
 	public function test_shows_api_key_form() {
+		$this->set_api_key( '' );
+
+		ob_start();
+		Admin\render_settings_page();
+		$output = ob_get_clean();
+
+		$this->assertContainsSelector( '#wp101-settings-api-key-form', $output );
+		$this->assertNotContainsSelector( '#wp101-settings-api-key-display', $output );
+		$this->assertHasElementWithAttributes(
+			[
+				'name'  => 'wp101_api_key',
+				'id'    => 'wp101-api-key',
+			],
+			$output
+		);
+
+		$this->assertEquals( 1, did_action( 'admin_notices' ) );
+	}
+
+	public function test_hides_api_key_form_if_already_set() {
 		$key = $this->set_api_key();
 
 		ob_start();
@@ -24,9 +44,15 @@ class SettingsTest extends TestCase {
 
 		$this->assertHasElementWithAttributes(
 			[
-				'name'  => 'wp101_api_key',
-				'id'    => 'wp101-api-key',
-				'value' => $key,
+				'id'    => 'wp101-settings-api-key-form',
+				'class' => 'hide-if-js',
+			],
+			$output
+		);
+
+		$this->assertHasElementWithAttributes(
+			[
+				'id'    => 'wp101-settings-api-key-display',
 			],
 			$output
 		);
@@ -46,6 +72,7 @@ class SettingsTest extends TestCase {
 
 		$this->assertContainsSelector( '#wp101-api-key-set-via-constant-notice', $output );
 		$this->assertNotContainsSelector( '#wp101-api-key', $output );
+		$this->assertNotContainsSelector(' #wp101-settings-replace-api-key', $output );
 	}
 
 	public function test_public_key_is_cleared_when_private_key_changes() {

--- a/views/settings.php
+++ b/views/settings.php
@@ -46,7 +46,7 @@ $masked = str_pad(
 
 	<?php else : ?>
 
-		<div id="wp101-settings-api-key-form" <?php echo ( $api_key ) ? 'class="hide-if-js"' : ''; ?>>
+		<div id="wp101-settings-api-key-form" <?php echo ! empty( $api_key ) ? 'class="hide-if-js"' : ''; ?>>
 			<form method="post" action="options.php">
 				<?php settings_fields( 'wp101' ); ?>
 
@@ -65,7 +65,7 @@ $masked = str_pad(
 
 	<?php endif; ?>
 
-	<?php if ( $api_key ) : ?>
+	<?php if ( ! empty( $api_key ) ) : ?>
 
 		<div id="wp101-settings-api-key-display">
 			<table class="form-table">

--- a/views/settings.php
+++ b/views/settings.php
@@ -8,6 +8,8 @@
 use WP101\Migrate as Migrate;
 use WP101\TemplateTags as TemplateTags;
 
+$api_key = TemplateTags\get_api_key();
+
 ?>
 
 <div class="wrap wp101-settings">
@@ -15,7 +17,13 @@ use WP101\TemplateTags as TemplateTags;
 
 	<?php settings_errors(); ?>
 
+	<h2 id="api-key"><?php echo esc_html( _x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ) ); ?></h2>
+	<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
+	<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>
+	<p><a href="https://wp101plugin.com" class="button" target="_blank"><?php esc_html_e( 'Get your key now!', 'wp101' ); ?></a></p>
+
 	<?php if ( defined( 'WP101_API_KEY' ) ) : ?>
+
 		<div id="wp101-api-key-set-via-constant-notice" class="notice notice-info">
 			<p><strong><?php esc_html_e( 'Your API key is defined in your wp-config.php file.', 'wp101' ); ?></strong></p>
 			<p><?php esc_html_e( 'To make changes, please open your wp-config.php file in a text editor and look for the line that includes:', 'wp101' ); ?></p>
@@ -24,25 +32,40 @@ use WP101\TemplateTags as TemplateTags;
 
 	<?php else : ?>
 
-		<form method="post" action="options.php">
-			<?php settings_fields( 'wp101' ); ?>
+		<div id="wp101-settings-api-key-form" <?php echo ( $api_key ) ? 'class="hide-if-js"' : ''; ?>>
+			<form method="post" action="options.php">
+				<?php settings_fields( 'wp101' ); ?>
 
-			<section id="api-key">
-				<h2><?php echo esc_html( _x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ) ); ?></h2>
-				<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
-				<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>
-				<p><a href="https://wp101plugin.com" target="_blank"><?php esc_html_e( 'Sign up to get your key now!', 'wp101' ); ?></a></p>
 				<table class="form-table">
 					<th scope="row">
 						<label for="wp101-api-key"><?php esc_html_e( 'API key', 'wp101' ); ?></label>
 					</th>
 					<td>
-						<input name="wp101_api_key" id="wp101-api-key" type="text" value="<?php echo esc_attr( TemplateTags\get_api_key() ); ?>" class="regular-text code" />
+						<input name="wp101_api_key" id="wp101-api-key" type="text" class="regular-text code" />
 					</td>
 				</table>
 
-			</section>
-			<?php submit_button(); ?>
-		</form>
+				<?php submit_button(); ?>
+			</form>
+		</div>
+
+	<?php endif; ?>
+
+	<?php if ( $api_key ) : ?>
+
+		<div id="wp101-settings-api-key-display">
+			<table class="form-table">
+				<th scope="row">
+					<label for="wp101-api-key"><?php esc_html_e( 'API key', 'wp101' ); ?></label>
+				</th>
+				<td>
+					<code><?php echo esc_html( $api_key ); ?></code>
+					<?php if ( ! defined( 'WP101_API_KEY' ) ) : ?>
+						<button id="wp101-settings-replace-api-key" class="button" style="vertical-align: baseline;"><?php esc_html_e( 'Replace my API Key', 'wp101' ); ?></button>
+					<?php endif; ?>
+				</td>
+			</table>
+		</div>
+
 	<?php endif; ?>
 </div>

--- a/views/settings.php
+++ b/views/settings.php
@@ -10,6 +10,20 @@ use WP101\TemplateTags as TemplateTags;
 
 $api_key = TemplateTags\get_api_key();
 
+/*
+ * Mask the API key, showing only the first four characters.
+ *
+ * The rest should be replaced with "&#9679;", a Unicode black circle.
+ *
+ * Masked keys will look something like: "ABCD●●●●●●●●●●●●●●●●●●●●●●●●●●●●".
+ */
+$masked = str_pad(
+	substr( $api_key, 0, 4 ),
+	4 + 7 * ( strlen( $api_key ) - 4 ),
+	'&#9679;',
+	STR_PAD_RIGHT
+);
+
 ?>
 
 <div class="wrap wp101-settings">
@@ -59,7 +73,7 @@ $api_key = TemplateTags\get_api_key();
 					<label for="wp101-api-key"><?php esc_html_e( 'API key', 'wp101' ); ?></label>
 				</th>
 				<td>
-					<code><?php echo esc_html( $api_key ); ?></code>
+					<code><?php echo esc_html( $masked ); ?></code>
 					<?php if ( ! defined( 'WP101_API_KEY' ) ) : ?>
 						<button id="wp101-settings-replace-api-key" class="button" style="vertical-align: baseline;"><?php esc_html_e( 'Replace my API Key', 'wp101' ); ?></button>
 					<?php endif; ?>

--- a/views/settings.php
+++ b/views/settings.php
@@ -31,7 +31,7 @@ $masked = str_pad(
 
 	<?php settings_errors(); ?>
 
-	<h2 id="api-key"><?php echo esc_html( _x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ) ); ?></h2>
+	<h2 id="api-key"><?php echo esc_html_x( 'WP101Plugin.com API Key', 'settings section heading', 'wp101' ); ?></h2>
 	<p><?php esc_html_e( 'Your API key enables your WordPress site to connect to WP101 and retrieve all of your videos.', 'wp101' ); ?></p>
 	<p><strong><?php esc_html_e( 'Don\'t have an API key?', 'wp101' ); ?></strong></p>
 	<p><a href="https://wp101plugin.com" class="button" target="_blank"><?php esc_html_e( 'Get your key now!', 'wp101' ); ?></a></p>


### PR DESCRIPTION
This PR masks the stored API key on the "Video Tutorials > Settings" page. It also adds custom success messages, ensuring that users aren't left to wonder "okay, so I've set my API key...now what?"

**Once an API key has been set through the UI:**

![Successful setting of the API key](https://user-images.githubusercontent.com/233836/42184635-32458cac-7e14-11e8-957e-9b7624743f26.png)

**Upon clicking "Replace my API Key":**
![WP101 settings screen upon clicking "Replace my API Key"](https://user-images.githubusercontent.com/233836/42184750-90ca0e24-7e14-11e8-9ebc-4e7acdcd2e97.png)

**Entering an invalid API key:**

![WP101 settings screen with an "Invalid API key!" error message](https://user-images.githubusercontent.com/233836/42184779-ab548922-7e14-11e8-9a22-0e151d2763ec.png)

**API key has been set via constant:**

![The WP101 plugin settings screen warning the user that the API key has been defined as a constant in wp-config.php](https://user-images.githubusercontent.com/233836/42184804-bd8197c0-7e14-11e8-9174-ac2ceaffc6a5.png)

Fixes liquidweb/wp101-app#193.