### PR TITLE
Fix double notifications on the settings page

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -212,9 +212,6 @@ function render_listings_page() {
 function render_settings_page() {
 	Migrate\maybe_migrate();
 
-	/** This action is documented in wp-admin/admin-header.php. */
-	do_action( 'admin_notices' );
-
 	include WP101_VIEWS . '/settings.php';
 }
 

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -31,8 +31,6 @@ class SettingsTest extends TestCase {
 			],
 			$output
 		);
-
-		$this->assertEquals( 1, did_action( 'admin_notices' ) );
 	}
 
 	public function test_hides_api_key_form_if_already_set() {
@@ -62,8 +60,6 @@ class SettingsTest extends TestCase {
 			'/\<code\>' . preg_quote( substr( $key, 0, 4 ) ) . '(&#9679;)+\<\/code\>/',
 			$output
 		);
-
-		$this->assertEquals( 1, did_action( 'admin_notices' ) );
 	}
 
 	/**


### PR DESCRIPTION
Remove an explicit call to `do_action( 'admin_notices' )` within WP101\Admin\render_settings_page(), as it caused alerts to be rendered twice.

Fixes #50.