### PR TITLE
Refactor error handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "stevegrunwell/phpunit-markup-assertions": "^1.0",
     "stevegrunwell/runkit7-installer": "^1.0",
     "wimg/php-compatibility": "^8.1",
-    "wp-coding-standards/wpcs": "^0.14.1"
+    "wp-coding-standards/wpcs": "^1.0.0"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d98c8863415ec82e040faa7b0b5aa81",
+    "content-hash": "3850c905e715a61aaf656ae042d52348",
     "packages": [],
     "packages-dev": [
         {
@@ -544,16 +544,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -565,12 +565,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -603,7 +603,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -856,16 +856,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.8",
+            "version": "6.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b"
+                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
-                "reference": "4f21a3c6b97c42952fd5c2837bb354ec0199b97b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7bab54cb366076023bbf457a2a0d513332cd40f2",
+                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2",
                 "shasum": ""
             },
             "require": {
@@ -883,7 +883,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -936,20 +936,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-10T11:38:34+00:00"
+            "time": "2018-08-07T07:05:35+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.7",
+            "version": "5.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce"
+                "reference": "141129c578f58f38f55eccf15a1039bd413ea57c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
-                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/141129c578f58f38f55eccf15a1039bd413ea57c",
+                "reference": "141129c578f58f38f55eccf15a1039bd413ea57c",
                 "shasum": ""
             },
             "require": {
@@ -995,7 +995,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-05-29T13:50:43+00:00"
+            "time": "2018-08-07T07:02:44+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1558,16 +1558,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.2.3",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+                "reference": "628a481780561150481a9ec74709092b9759b3ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
-                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec",
                 "shasum": ""
             },
             "require": {
@@ -1605,7 +1605,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-02-20T21:35:23+00:00"
+            "time": "2018-07-26T23:47:18+00:00"
         },
         {
             "name": "stevegrunwell/phpunit-markup-assertions",
@@ -1654,16 +1654,16 @@
         },
         {
             "name": "stevegrunwell/runkit7-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stevegrunwell/runkit7-installer.git",
-                "reference": "ee618b7877fb1d6cb5930f48c9b845044c4c684c"
+                "reference": "94d70144c39c189ffc145fb7a6216d911b2a65aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stevegrunwell/runkit7-installer/zipball/ee618b7877fb1d6cb5930f48c9b845044c4c684c",
-                "reference": "ee618b7877fb1d6cb5930f48c9b845044c4c684c",
+                "url": "https://api.github.com/repos/stevegrunwell/runkit7-installer/zipball/94d70144c39c189ffc145fb7a6216d911b2a65aa",
+                "reference": "94d70144c39c189ffc145fb7a6216d911b2a65aa",
                 "shasum": ""
             },
             "require-dev": {
@@ -1690,7 +1690,7 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2018-03-30T03:00:06+00:00"
+            "time": "2018-06-27T18:45:37+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1784,30 +1784,31 @@
         },
         {
             "name": "wimg/php-compatibility",
-            "version": "8.1.0",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
             },
             "conflict": {
                 "squizlabs/php_codesniffer": "2.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -1817,7 +1818,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -1832,28 +1833,31 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-12-27T21:58:38+00:00"
+            "time": "2018-07-17T13:42:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/539c6d74e6207daa22b7ea754d6f103e9abb2755",
+                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "*"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1872,7 +1876,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-07-25T18:10:35+00:00"
         },
         {
             "name": "zendframework/zend-dom",

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -117,13 +117,14 @@ add_action( 'current_screen', __NAMESPACE__ . '\show_notifications' );
  * @param array  $slug    An array of one or more add-on slugs, to be flattened into a data attribute.
  */
 function render_notification( $message, $slug ) {
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<div class="notice notice-info is-dismissible" data-wp101-addon-slug="<?php echo esc_attr( implode( ',', (array) $slug ) ); ?>">
 		<p><?php echo wp_kses_post( $message ); ?></p>
 	</div>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 }
 
 /**

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -42,9 +42,11 @@ function enqueue_scripts( $hook ) {
 	);
 
 	// Only enqueue on WP101 pages.
-	if ( 'toplevel_page_wp101' === $hook || preg_match( '/^video-tutorials_page_wp101/', $hook ) ) {
+	if ( false !== strpos( $hook, 'wp101' ) ) {
 		wp_enqueue_style( 'wp101-admin' );
 		wp_enqueue_script( 'wp101-admin' );
+
+		add_action( 'admin_notices', __NAMESPACE__ . '\display_api_errors' );
 	}
 }
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
@@ -254,4 +256,22 @@ function is_relevant_series( $series ) {
 	$restrictions = array_filter( $series['restrictions']['plugins'], 'is_plugin_active' );
 
 	return ! empty( $restrictions );
+}
+
+/**
+ * Inject admin notices from the API into WP Admin, but only on WP101 pages.
+ */
+function display_api_errors() {
+	$api = TemplateTags\api();
+
+	foreach ( $api->get_errors() as $error ) {
+		// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
+?>
+
+	<div class="notice notice-error">
+		<p><?php echo wp_kses_post( $error->get_error_message() ); ?></p>
+	</div>
+
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
+	}
 }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -69,8 +69,10 @@ function get_addon_capability() {
  */
 function register_menu_pages() {
 
-	// If the API key hasn't been configured, *only* show the settings page.
-	if ( ! TemplateTags\api()->has_api_key() ) {
+	// If we can't retrieve a playlist, *only* show the settings page.
+	$playlist = TemplateTags\api()->get_playlist();
+
+	if ( empty( $playlist['series'] ) ) {
 		return add_menu_page(
 			_x( 'WP101', 'page title', 'wp101' ),
 			_x( 'Video Tutorials', 'menu title', 'wp101' ),

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -19,6 +19,13 @@ class API {
 	protected $api_key;
 
 	/**
+	 * A roll-up of any and all API errors that have occurred.
+	 *
+	 * @var array
+	 */
+	protected $errors = [];
+
+	/**
 	 * The Singleton instance.
 	 *
 	 * @var API
@@ -112,6 +119,15 @@ class API {
 	}
 
 	/**
+	 * Retrieve any API errors that have occurred.
+	 *
+	 * @return array An array of WP_Error objects.
+	 */
+	public function get_errors() {
+		return $this->errors;
+	}
+
+	/**
 	 * Retrieve an *uncached* response from the /account endpoint.
 	 *
 	 * @return array An array of all account attributes or an empty array if no account was found.
@@ -166,7 +182,7 @@ class API {
 		$response = $this->send_request( 'GET', '/add-ons', [], [], 12 * HOUR_IN_SECONDS );
 
 		if ( is_wp_error( $response ) ) {
-			$this->handle_error( $response, E_USER_WARNING );
+			$this->handle_error( $response );
 
 			return [
 				'addons' => [],
@@ -207,7 +223,7 @@ class API {
 		$response = $this->send_request( 'GET', '/playlist' );
 
 		if ( is_wp_error( $response ) ) {
-			$this->handle_error( $response, E_USER_WARNING );
+			$this->handle_error( $response );
 
 			return [
 				'series' => [],
@@ -432,12 +448,9 @@ class API {
 	 * Trigger an error and optionally block subsequent API requests.
 	 *
 	 * @param WP_Error $error The WP_Error object.
-	 * @param string   $level Optional. The PHP E_USER_* error level. Default is E_USER_WARNING.
 	 */
-	protected function handle_error( $error, $level = E_USER_WARNING ) {
-		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( esc_html( $error->get_error_message() ), $level );
-		// phpcs:enable
+	protected function handle_error( $error ) {
+		$this->errors[ $error->get_error_code() ] = $error;
 	}
 
 	/**

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -166,9 +166,7 @@ class API {
 		$response = $this->send_request( 'GET', '/add-ons', [], [], 12 * HOUR_IN_SECONDS );
 
 		if ( is_wp_error( $response ) ) {
-			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			trigger_error( esc_html( $response->get_error_message() ), E_USER_WARNING );
-			// phpcs:enable
+			$this->handle_error( $response, E_USER_WARNING );
 
 			return [
 				'addons' => [],
@@ -209,9 +207,7 @@ class API {
 		$response = $this->send_request( 'GET', '/playlist' );
 
 		if ( is_wp_error( $response ) ) {
-			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			trigger_error( esc_html( $response->get_error_message() ), E_USER_WARNING );
-			// phpcs:enable
+			$this->handle_error( $response, E_USER_WARNING );
 
 			return [
 				'series' => [],
@@ -430,6 +426,18 @@ class API {
 		}
 
 		return $body['data'];
+	}
+
+	/**
+	 * Trigger an error and optionally block subsequent API requests.
+	 *
+	 * @param WP_Error $error The WP_Error object.
+	 * @param string   $level Optional. The PHP E_USER_* error level. Default is E_USER_WARNING.
+	 */
+	protected function handle_error( $error, $level = E_USER_WARNING ) {
+		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		trigger_error( esc_html( $error->get_error_message() ), $level );
+		// phpcs:enable
 	}
 
 	/**

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -15,9 +15,9 @@ namespace WP101\Deprecated;
  * @param string $version The plugin version in which the feature was deprecated.
  */
 function mark_deprecated( $feature, $message, $version ) {
-	// phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
+	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	return _doing_it_wrong( $feature, $message, $version );
-	// phpcs:enable
+	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 /**

--- a/includes/migrate.php
+++ b/includes/migrate.php
@@ -87,32 +87,35 @@ function wp_config_requires_updating() {
  * Display a notification when an automatic migration has succeeded.
  */
 function render_migration_success_notice() {
+	// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<div id="wp101-api-key-upgraded" class="notice notice-success">
 		<p><?php esc_html_e( 'WP101 has automatically upgraded your API key to work with the latest version!', 'wp101' ); ?></p>
 	</div>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 }
 
 /**
  * Display a notification when an automatic migration has failed.
  */
 function render_migration_failure_notice() {
+	// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<div id="wp101-api-key-upgrade-failed" class="notice notice-error">
 		<p><?php esc_html_e( 'WP101 was unable to automatically migrate your API key for the latest version.', 'wp101' ); ?></p>
 	</div>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 }
 
 /**
  * Display a notification when the WP101_API_KEY constant in wp-config.php needs updating.
  */
 function render_constant_upgrade_notice() {
+	// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<div id="wp101-api-key-constant-upgrade-notice" class="notice notice-warning">
@@ -132,13 +135,14 @@ function render_constant_upgrade_notice() {
 			<li><?php esc_html_e( 'Save the wp-config.php file on your web server.', 'wp101' ); ?></li>
 	</div>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 }
 
 /**
  * Display a notification when the WP101_API_KEY constant in wp-config.php is blocking progress.
  */
 function render_constant_empty_notice() {
+	// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<div id="wp101-api-key-constant-empty-notice" class="notice notice-warning">
@@ -157,5 +161,5 @@ function render_constant_empty_notice() {
 			<li><?php esc_html_e( 'Save the wp-config.php file on your web server.', 'wp101' ); ?></li>
 	</div>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 }

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -99,6 +99,7 @@ function render_shortcode_single( $topic ) {
 	];
 
 	ob_start();
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<figure class="wp101-video">
@@ -113,7 +114,7 @@ function render_shortcode_single( $topic ) {
 		</figcaption>
 	</figure>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 	$output = ob_get_clean();
 
 	/**
@@ -141,6 +142,7 @@ function render_shortcode_playlist( $series ) {
 	];
 
 	ob_start();
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 
 	<section class="wp101-video-grid">
@@ -163,7 +165,7 @@ function render_shortcode_playlist( $series ) {
 		</div>
 	</section>
 
-<?php
+<?php // phpcs:enable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 	$output = ob_get_clean();
 
 	/**

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -34,7 +34,12 @@ class AdminTest extends TestCase {
 	/**
 	 * Ensure that WP101 assets are only enqueued on WP101 pages.
 	 *
-	 * @dataProvider enqueue_hook_provider()
+	 * @testWith ["some-hook", false]
+	 *           ["wp101", true]
+	 *           ["toplevel_page_wp101", true]
+	 *           ["video-tutorials_page_wp101-settings", true]
+	 *           ["video-tutorials_page_wp101-addons", true]
+	 *           ["random-wp101", true]
 	 *
 	 * @param string $hook     The hook to be executed.
 	 * @param bool   $enqueued Whether or not the assets should be enqueued for this hook.
@@ -42,20 +47,12 @@ class AdminTest extends TestCase {
 	public function test_enqueue_scripts_enqueues_on_wp101_pages( $hook, bool $enqueued ) {
 		Admin\enqueue_scripts( $hook );
 
-		$this->assertEquals( $enqueued, wp_style_is( 'wp101-admin', 'enqueued' ) );
-		$this->assertEquals( $enqueued, wp_script_is( 'wp101-admin', 'enqueued' ) );
-	}
+		$this->assertSame( $enqueued, wp_style_is( 'wp101-admin', 'enqueued' ) );
+		$this->assertSame( $enqueued, wp_script_is( 'wp101-admin', 'enqueued' ) );
 
-	/**
-	 * Data provider for test_enqueue_scripts_enqueues_on_wp101_pages().
-	 */
-	public function enqueue_hook_provider() {
-		return [
-			'Generic page'   => [ 'some-hook', false ],
-			'WP101 listings' => [ 'toplevel_page_wp101', true ],
-			'WP101 settings' => [ 'video-tutorials_page_wp101-settings', true ],
-			'WP101 add-ons'  => [ 'video-tutorials_page_wp101-addons', true ],
-		];
+		if ( $enqueued ) {
+			$this->assertSame( 10, has_action( 'admin_notices', 'WP101\Admin\display_api_errors' ) );
+		}
 	}
 
 	public function test_get_addon_capability() {

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -82,7 +82,13 @@ class AdminTest extends TestCase {
 		] ) );
 
 		$api = $this->mock_api();
-		$api->set_api_key( md5( uniqid() ) );
+		$api->shouldReceive( 'get_playlist' )
+			->once()
+			->andReturn( [
+				'series' => [
+					'some series',
+				],
+			] );
 		$api->shouldReceive( 'get_addons' )
 			->once()
 			->andReturn( [
@@ -110,12 +116,17 @@ class AdminTest extends TestCase {
 	/**
 	 * If an API key hasn't been set, only the WP101 Settings page should be shown.
 	 */
-	public function test_register_menu_pages_hides_listings_if_no_api_key_is_set() {
+	public function test_register_menu_pages_hides_listings_if_listings_are_available() {
 		wp_set_current_user( $this->factory()->user->create( [
 			'role' => 'administrator',
 		] ) );
 
-		$this->set_api_key( '' );
+		$api = $this->mock_api();
+		$api->shouldReceive( 'get_playlist' )
+			->once()
+			->andReturn( [
+				'series' => [],
+			] );
 
 		$menu = $this->get_menu_items();
 
@@ -128,7 +139,12 @@ class AdminTest extends TestCase {
 		] ) );
 
 		$api = $this->mock_api();
-		$api->set_api_key( md5( uniqid() ) );
+		$api->shouldReceive( 'get_playlist' )
+			->andReturn( [
+				'series' => [
+					'some series',
+				],
+			] );
 		$api->shouldReceive( 'get_addons' )
 			->once()
 			->andReturn( [

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -9,7 +9,6 @@ namespace WP101\Tests;
 
 use PHPUnit\Framework\Error\Error;
 use PHPUnit\Framework\Error\Warning;
-use ReflectionProperty;
 use WP_Error;
 use WP101\API;
 use WP101_Plugin;
@@ -30,7 +29,7 @@ class ApiTest extends TestCase {
 		$api = API::get_instance();
 		$key = md5( uniqid() );
 
-		$prop = new ReflectionProperty( $api, 'api_key' );
+		$prop = new \ReflectionProperty( $api, 'api_key' );
 		$prop->setAccessible( true );
 		$prop->setValue( $api, $key );
 
@@ -694,6 +693,22 @@ class ApiTest extends TestCase {
 		);
 	}
 
+	public function test_send_request_checks_response_status() {
+		$api    = API::get_instance();
+		$method = $this->get_accessible_method( $api, 'send_request' );
+
+		$response = $this->set_expected_response( [
+			'body' => wp_json_encode( [
+				'status'  => 'fail',
+				'data'    => [
+					'apiKey' => 'Invalid API key.',
+				],
+			] ),
+		] );
+
+		$this->assertTrue( is_wp_error( $method->invoke( $api, 'GET', '/test-endpoint' ) ) );
+	}
+
 	/**
 	 * @testWith ["some message", "warning"]
 	 *           ["some other message", "warning"]
@@ -714,22 +729,6 @@ class ApiTest extends TestCase {
 		}
 
 		$this->fail( 'Did not receive expected exception' );
-	}
-
-	public function test_send_request_checks_response_status() {
-		$api    = API::get_instance();
-		$method = $this->get_accessible_method( $api, 'send_request' );
-
-		$response = $this->set_expected_response( [
-			'body' => wp_json_encode( [
-				'status'  => 'fail',
-				'data'    => [
-					'apiKey' => 'Invalid API key.',
-				],
-			] ),
-		] );
-
-		$this->assertTrue( is_wp_error( $method->invoke( $api, 'GET', '/test-endpoint' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR adjusts the way the `API` class handles errors: rather than simply calling `trigger_error()`, the errors are stored in a (protected) `$errors` array, then rendered on WP101-specific pages. The errors are tracked based on their keys, meaning we won't see multiple messages for the same error (fixes #52).