### PR TITLE
Store the public API in a long-lasting transient instead of an option

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -223,7 +223,7 @@ function render_settings_page() {
  * Flush the public key after saving the private key.
  */
 function clear_public_api_key() {
-	delete_option( API::PUBLIC_API_KEY_OPTION );
+	delete_transient( API::PUBLIC_API_KEY_OPTION );
 
 	// Prime the cache with the new public + private keys.
 	$api = TemplateTags\api();

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -42,7 +42,14 @@ class API {
 	const API_URL = 'https://app.wp101plugin.com/api';
 
 	/**
-	 * Option key for the site's public API key.
+	 * Option key for the site's (private) API key.
+	 *
+	 * @var string
+	 */
+	const API_KEY_OPTION = 'wp101_api_key';
+
+	/**
+	 * Transient key for the site's public API key.
 	 *
 	 * @var string
 	 */
@@ -96,7 +103,7 @@ class API {
 		if ( defined( 'WP101_API_KEY' ) ) {
 			$this->api_key = WP101_API_KEY;
 		} else {
-			$this->api_key = get_option( 'wp101_api_key', null );
+			$this->api_key = get_option( self::API_KEY_OPTION, null );
 		}
 
 		return $this->api_key;
@@ -151,7 +158,7 @@ class API {
 	 * @return string|WP_Error The public API key or any WP_Error that occurred.
 	 */
 	public function get_public_api_key() {
-		$public_key = get_option( self::PUBLIC_API_KEY_OPTION );
+		$public_key = get_transient( self::PUBLIC_API_KEY_OPTION );
 
 		if ( $public_key ) {
 			return $public_key;
@@ -168,7 +175,7 @@ class API {
 
 		$public_key = $response['publicKey'];
 
-		update_option( self::PUBLIC_API_KEY_OPTION, $public_key, false );
+		set_transient( self::PUBLIC_API_KEY_OPTION, $public_key, 0 );
 
 		return $public_key;
 	}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -124,7 +124,7 @@ class ApiTest extends TestCase {
 	}
 
 	public function test_get_public_api_key() {
-		$this->assertFalse( get_option( API::PUBLIC_API_KEY_OPTION ) );
+		$this->assertFalse( get_transient( API::PUBLIC_API_KEY_OPTION ) );
 
 		$json = [
 			'status' => 'success',
@@ -144,13 +144,13 @@ class ApiTest extends TestCase {
 			$key,
 			'The public API should be determined by the WP101 API.'
 		);
-		$this->assertEquals( $key, get_option( API::PUBLIC_API_KEY_OPTION ) );
+		$this->assertEquals( $key, get_transient( API::PUBLIC_API_KEY_OPTION ) );
 	}
 
-	public function test_get_public_api_key_returns_from_options_table_if_populated() {
+	public function test_get_public_api_key_returns_from_transients_if_populated() {
 		$key = uniqid();
 
-		update_option( API::PUBLIC_API_KEY_OPTION, $key );
+		set_transient( API::PUBLIC_API_KEY_OPTION, $key, 0 );
 
 		$this->assertEquals( $key, API::get_instance()->get_public_api_key() );
 	}
@@ -227,7 +227,7 @@ class ApiTest extends TestCase {
 	public function test_get_addons_updates_add_on_urls() {
 		$api_key = uniqid();
 
-		update_option( API::PUBLIC_API_KEY_OPTION, $api_key );
+		set_transient( API::PUBLIC_API_KEY_OPTION, $api_key );
 		$this->set_expected_response([
 			'body' => wp_json_encode( [
 				'status' => 'success',

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -79,7 +79,7 @@ class SettingsTest extends TestCase {
 
 	public function test_public_key_is_cleared_when_private_key_changes() {
 		update_option( 'wp101_api_key', md5( uniqid() ) );
-		update_option( API::PUBLIC_API_KEY_OPTION, uniqid() );
+		set_transient( API::PUBLIC_API_KEY_OPTION, uniqid(), 0 );
 
 		$api = $this->mock_api();
 		$api->shouldReceive( 'clear_api_key' )->once();
@@ -88,6 +88,6 @@ class SettingsTest extends TestCase {
 		// Change the private key.
 		update_option( 'wp101_api_key', md5( uniqid() ) );
 
-		$this->assertEmpty( get_option( API::PUBLIC_API_KEY_OPTION ) );
+		$this->assertFalse( get_transient( API::PUBLIC_API_KEY_OPTION ) );
 	}
 }

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -17,12 +17,11 @@ class UninstallTest extends TestCase {
 
 	public function test_uninstall_script_clears_known_options() {
 		$options = array(
-			'wp101_api_key',
+			API::API_KEY_OPTION,
 			'wp101_db_version',
 			'wp101_hidden_topics',
 			'wp101_custom_topics',
 			'wp101_admin_restriction',
-			API::PUBLIC_API_KEY_OPTION,
 		);
 
 		foreach ( $options as $option ) {
@@ -41,6 +40,7 @@ class UninstallTest extends TestCase {
 
 	public function test_uninstall_script_clears_known_transients() {
 		$transients = array(
+			API::PUBLIC_API_KEY_OPTION,
 			'wp101_topics',
 			'wp101_jetpack_topics',
 			'wp101_woocommerce_topics',

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -24,6 +24,7 @@ class TestCase extends WP_UnitTestCase {
 		parent::tearDown();
 
 		delete_option( 'wp101_api_key' );
+		delete_transient( API::PUBLIC_API_KEY_OPTION );
 
 		$instance = new ReflectionProperty( API::get_instance(), 'instance' );
 		$instance->setAccessible( true );


### PR DESCRIPTION
This PR updates the storage of public API keys so they're stored in transients rather than directly in the options table.

Typically, a site is going to flush its caches (object cache + transient) after changing the site domain; this PR ensures the public key is more likely to go, since the public key is unique per private API key + domain combination.