### PR TITLE
Flush WP101 caches on plugin deactivation

### DIFF
--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -12,15 +12,20 @@ use WP101\Admin as Admin;
 /**
  * Clean up WP101 configuration when the plugin is uninstalled.
  */
-function cleanup_plugin() {
-
-	// Delete WP101 options.
+function uninstall_plugin() {
 	delete_option( 'wp101_api_key' );
 	delete_option( 'wp101_db_version' );
 	delete_option( 'wp101_hidden_topics' );
 	delete_option( 'wp101_custom_topics' );
 	delete_option( 'wp101_admin_restriction' );
 
+	clear_caches();
+}
+
+/**
+ * Delete all known WP101 transients + caches.
+ */
+function clear_caches() {
 	Admin\clear_public_api_key();
 
 	// Delete WP101 transients.

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -15,7 +15,14 @@ use WP101\Uninstall as Uninstall;
  */
 class UninstallTest extends TestCase {
 
-	public function test_uninstall_script_clears_known_options() {
+	public function test_deactivation_hook_registered() {
+		$this->assertEquals( 10, has_action(
+			'deactivate_' . substr( dirname( __DIR__ ) . '/wp101.php', 1 ),
+			'WP101\\Uninstall\\clear_caches'
+		), 'Expected to see clear_caches called on plugin deactivation.' );
+	}
+
+	public function test_uninstall_plugin() {
 		$options = array(
 			API::API_KEY_OPTION,
 			'wp101_db_version',
@@ -28,17 +35,17 @@ class UninstallTest extends TestCase {
 			add_option( $option, uniqid() );
 		}
 
-		Uninstall\cleanup_plugin();
+		Uninstall\uninstall_plugin();
 
 		foreach ( $options as $option ) {
 			$this->assertEmpty(
 				get_option( $option ),
-				"Option '$option' was not removed along with the plugin"
+				"Option '$option' was not removed along with the plugin."
 			);
 		}
 	}
 
-	public function test_uninstall_script_clears_known_transients() {
+	public function test_clear_caches() {
 		$transients = array(
 			API::PUBLIC_API_KEY_OPTION,
 			'wp101_topics',
@@ -54,12 +61,12 @@ class UninstallTest extends TestCase {
 			set_transient( $transient, uniqid() );
 		}
 
-		Uninstall\cleanup_plugin();
+		Uninstall\clear_caches();
 
 		foreach ( $transients as $transient ) {
 			$this->assertEmpty(
 				get_transient( $transient ),
-				"Transient '$transient' was not cleared along with the plugin"
+				"Transient '$transient' was not cleared."
 			);
 		}
 	}

--- a/wp101.php
+++ b/wp101.php
@@ -41,6 +41,11 @@ if ( ! defined( 'DISABLE_NAG_NOTICES' ) || ! DISABLE_NAG_NOTICES ) {
 register_activation_hook( __FILE__, 'WP101\Migrate\maybe_migrate' );
 
 /**
+ * When the plugin is deactivated, flush caches.
+ */
+register_deactivation_hook( __FILE__, 'WP101\Uninstall\clear_caches' );
+
+/**
  * Register the uninstall callback.
  */
-register_uninstall_hook( __FILE__, 'WP101\Uninstall\cleanup_plugin' );
+register_uninstall_hook( __FILE__, 'WP101\Uninstall\uninstall_plugin' );


### PR DESCRIPTION
When a user deactivates the WP101 plugin, all of the WP101-specific transients + caches should be cleared.

As the public key is now stored in a transient, this will let users implicitly flush their public keys via a deactivate/reactivate routine.