### PR TITLE
Remove the non-public page restriction

### DIFF
--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -48,9 +48,6 @@ function render_shortcode( $atts ) {
 
 	if ( ! $api->account_can( 'embed-on-front-end' ) ) {
 		return shortcode_debug( __( 'Your WP101 subscription does not permit embedding on the front-end of a site.', 'wp101' ) );
-
-	} elseif ( 'private' !== get_post_status() && ! get_post()->post_password ) {
-		return shortcode_debug( __( 'You may not use WP101 shortcodes on public pages.', 'wp101' ) );
 	}
 
 	// Load the requisite files.

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -140,51 +140,6 @@ class ShortcodeTest extends TestCase {
 		);
 	}
 
-	public function test_hides_content_on_public_pages() {
-		$post = $this->factory()->post->create( [
-			'post_status' => 'publish',
-		] );
-		$api  = $this->mock_api();
-
-		$api->shouldReceive( 'account_can' )->andReturn( true );
-
-		$this->go_to( get_permalink( $post ) );
-
-		$this->assertEmpty(
-			Shortcode\render_shortcode( [
-				'video' => 'test-video',
-			] )
-		);
-	}
-
-	public function test_shows_content_on_password_protected_pages() {
-		wp_set_current_user( $this->factory()->user->create() );
-		Shortcode\register_scripts_styles();
-
-		$post = $this->factory()->post->create( [
-			'post_status'   => 'publish',
-			'post_password' => 'secret',
-		] );
-		$api  = $this->mock_api();
-
-		$api->shouldReceive( 'account_can' )->andReturn( true );
-		$api->shouldReceive( 'get_topic' )
-			->andReturn( [
-				'title'       => 'Title',
-				'slug'        => 'test-topic',
-				'url'         => 'http://example.com/test-topic',
-				'description' => 'Foo bar baz',
-			] );
-
-		$this->go_to( get_permalink( $post ) );
-
-		$this->assertNotEmpty(
-			Shortcode\render_shortcode( [
-				'video' => 'test-topic',
-			] )
-		);
-	}
-
 	public function test_shortcode_debug() {
 		$this->assertEmpty(
 			Shortcode\shortcode_debug( 'Foo bar' ),


### PR DESCRIPTION
Since most pro members aren't going to be using protected/private pages (WordPress native) in favor of membership plugins (e.g. MemberPress, et al), Shawn has made the decision to not disable the shortcode output on public pages at this time.