### PR TITLE
Return a WP_Error if no API key is set

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -183,7 +183,7 @@ function sanitize_api_key( $key ) {
 			'updated'
 		);
 	} else {
-		add_settings_error( 'wp101', 'api_key', __( 'Invalid API key!', 'wp101' ), 'error' );
+		add_settings_error( 'wp101', 'api_key', __( 'This API key is either invalid or has reached its maximum number of domains.', 'wp101' ), 'error' );
 		$key = '';
 	}
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -271,9 +271,16 @@ function is_relevant_series( $series ) {
  * Inject admin notices from the API into WP Admin, but only on WP101 pages.
  */
 function display_api_errors() {
-	$api = TemplateTags\api();
+	$api  = TemplateTags\api();
+	$skip = [
+		'wp101-no-api-key',
+	];
 
 	foreach ( $api->get_errors() as $error ) {
+		if ( in_array( $error->get_error_code(), $skip, true ) ) {
+			continue;
+		}
+
 		// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
 ?>
 

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -414,6 +414,15 @@ class API {
 	 * @return array|WP_Error The HTTP response body or a WP_Error object if something went wrong.
 	 */
 	protected function send_request( $method, $path, $query = [], $args = [], $cache = 0 ) {
+		$api_key = $this->get_api_key();
+
+		if ( empty( $api_key ) ) {
+			return new WP_Error(
+				'wp101-no-api-key',
+				__( 'No API key has been set, unable to make request.', 'wp101' )
+			);
+		}
+
 		$uri       = $this->build_uri( $path, $query );
 		$args      = wp_parse_args(
 			$args,
@@ -421,7 +430,7 @@ class API {
 				'timeout'    => 30,
 				'user-agent' => self::USER_AGENT,
 				'headers'    => [
-					'Authorization'    => 'Bearer ' . $this->get_api_key(),
+					'Authorization'    => 'Bearer ' . $api_key,
 					'Method'           => $method,
 					'X-Forwarded-Host' => site_url(),
 				],

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -7,6 +7,7 @@
 
 namespace WP101\Tests;
 
+use WP_Error;
 use WP101\Admin as Admin;
 use WP101\API as API;
 
@@ -301,6 +302,22 @@ class AdminTest extends TestCase {
 
 		$this->assertNotContains( get_admin_url( null, 'admin.php?page=wp101' ), $output );
 		$this->assertContains( 'notice-info', $output );
+	}
+
+	/**
+	 * @testWith ["wp101-no-api-key"]
+	 * @link https://github.com/liquidweb/wp101plugin/issues/67
+	 */
+	public function test_special_wp_errors_are_skipped_in_error_output( $code ) {
+		$api    = API::get_instance();
+		$method = $this->get_accessible_method( $api, 'handle_error' );
+		$method->invoke( $api, new WP_Error( $code, 'My error message' ) );
+
+		ob_start();
+		Admin\display_api_errors();
+		$output = ob_get_clean();
+
+		$this->assertNotContains( 'My error message', $output );
 	}
 
 	/**


### PR DESCRIPTION
Prevent HTTP requests from going out that we know will fail because an API key hasn't been set. Instead, return a WP_Error object that's explicitly excluded from appearing in the admin_notices.

Fixes #67.