### PR TITLE
Prevent sanitize_api_key() from being called twice

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -160,7 +160,19 @@ add_action( 'admin_init', __NAMESPACE__ . '\register_settings' );
  * @return string The sanitized key.
  */
 function sanitize_api_key( $key ) {
+	static $sanitized_api_key;
+
 	$key = sanitize_text_field( $key );
+
+	// Simply return the key if it's already been sanitized once.
+	if ( true === $sanitized_api_key ) {
+		return $key;
+	}
+
+	// Ensure this won't be run in its entirety a second time.
+	$sanitized_api_key = true;
+
+	// Verify the API key against the API.
 	$api = TemplateTags\api();
 	$api->set_api_key( $key );
 


### PR DESCRIPTION
When using WordPress' Settings API, there's a well-known bug where the option's sanitization callback will be called twice if the option doesn't yet exist in the database (reference: https://developer.wordpress.org/reference/functions/register_setting/#comment-content-2488).

Since the `Admin\sanitize_api_key()` function is somewhat expensive (since it makes an API call), this PR adds a simple static variable so it trips after running once.

Fixes #73.